### PR TITLE
Show both operation ID and name in visualization

### DIFF
--- a/cubed/extensions/rich.py
+++ b/cubed/extensions/rich.py
@@ -41,7 +41,10 @@ class RichProgressBar(Callback):
         progress_tasks = {}
         for name, node in visit_nodes(event.dag, event.resume):
             num_tasks = node["primitive_op"].num_tasks
-            progress_task = progress.add_task(f"{name}", start=False, total=num_tasks)
+            op_display_name = node["op_display_name"].replace("\n", " ")
+            progress_task = progress.add_task(
+                f"{op_display_name}", start=False, total=num_tasks
+            )
             progress_tasks[name] = progress_task
 
         self.logger_aware_progress = logger_aware_progress

--- a/cubed/extensions/tqdm.py
+++ b/cubed/extensions/tqdm.py
@@ -21,8 +21,13 @@ class TqdmProgressBar(Callback):
         i = 0
         for name, node in visit_nodes(event.dag, event.resume):
             num_tasks = node["primitive_op"].num_tasks
+            op_display_name = node["op_display_name"].replace("\n", " ")
             self.pbars[name] = tqdm(
-                *self.args, desc=name, total=num_tasks, position=i, **self.kwargs
+                *self.args,
+                desc=op_display_name,
+                total=num_tasks,
+                position=i,
+                **self.kwargs,
             )
             i = i + 1
 

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -457,7 +457,7 @@ def test_visualize(tmp_path):
     a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=xp.float64, chunks=(2, 2))
     b = cubed.random.random((3, 3), chunks=(2, 2))
     c = xp.add(a, b)
-    d = c * 2
+    d = c.rechunk((3, 1))
     e = c * 3
 
     f = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2))


### PR DESCRIPTION
Change plan visualization to always show array or op ID at top. For example:

![dg](https://github.com/cubed-dev/cubed/assets/85085/63e8ec63-948c-47ce-b4cb-c8b83eb193e7)

Progress bars also show the op ID and name now.