### PR TITLE
Track source array names in PrimitiveOperation 

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -739,6 +739,8 @@ def rechunk(x, chunks, target_store=None):
     temp_store = new_temp_path(name=name_int, spec=spec)
     ops = primitive_rechunk(
         x.zarray_maybe_lazy,
+        source_array_name=name,
+        int_array_name=name_int,
         target_chunks=target_chunks,
         allowed_mem=spec.allowed_mem,
         reserved_mem=spec.reserved_mem,

--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -462,6 +462,7 @@ def create_zarr_arrays(lazy_zarr_arrays, allowed_mem, reserved_mem):
     )
     return PrimitiveOperation(
         pipeline=pipeline,
+        source_array_names=[],
         target_array=None,
         projected_mem=projected_mem,
         allowed_mem=allowed_mem,

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -331,6 +331,7 @@ def general_blockwise(
     )
     return PrimitiveOperation(
         pipeline=pipeline,
+        source_array_names=array_names,
         target_array=target_array,
         projected_mem=projected_mem,
         allowed_mem=allowed_mem,
@@ -483,6 +484,7 @@ def fuse(
         write_proxy,
     )
 
+    source_array_names = primitive_op1.source_array_names
     target_array = primitive_op2.target_array
     projected_mem = max(primitive_op1.projected_mem, primitive_op2.projected_mem)
     allowed_mem = primitive_op2.allowed_mem
@@ -497,6 +499,7 @@ def fuse(
     )
     return PrimitiveOperation(
         pipeline=pipeline,
+        source_array_names=source_array_names,
         target_array=target_array,
         projected_mem=projected_mem,
         allowed_mem=allowed_mem,
@@ -607,6 +610,12 @@ def fuse_multiple(
         write_proxy,
     )
 
+    source_array_names = []
+    for i, p in enumerate(predecessor_primitive_ops):
+        if p is None:
+            source_array_names.append(primitive_op.source_array_names[i])
+        else:
+            source_array_names.extend(p.source_array_names)
     target_array = primitive_op.target_array
     projected_mem = max(
         primitive_op.projected_mem,
@@ -624,6 +633,7 @@ def fuse_multiple(
     )
     return PrimitiveOperation(
         pipeline=fused_pipeline,
+        source_array_names=source_array_names,
         target_array=target_array,
         projected_mem=projected_mem,
         allowed_mem=allowed_mem,

--- a/cubed/primitive/types.py
+++ b/cubed/primitive/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 import zarr
 
@@ -14,6 +14,9 @@ class PrimitiveOperation:
 
     pipeline: CubedPipeline
     """The pipeline that runs this operation."""
+
+    source_array_names: List[str]
+    """The names of the arrays which are inputs to this operation."""
 
     target_array: Any
     """The array being computed by this operation."""

--- a/cubed/tests/primitive/test_rechunk.py
+++ b/cubed/tests/primitive/test_rechunk.py
@@ -65,6 +65,8 @@ def test_rechunk(
 
     ops = rechunk(
         source,
+        source_array_name="source-array",
+        int_array_name="int-array",
         target_chunks=target_chunks,
         allowed_mem=allowed_mem,
         reserved_mem=reserved_mem,
@@ -109,6 +111,8 @@ def test_rechunk_allowed_mem_exceeded(tmp_path):
     ):
         rechunk(
             source,
+            source_array_name="source-array",
+            int_array_name="int-array",
             target_chunks=(4, 1),
             allowed_mem=allowed_mem,
             reserved_mem=0,


### PR DESCRIPTION
Fixes a bug with argument ordering found in https://github.com/cubed-dev/cubed/pull/412#issuecomment-1980734066.

The bug was due to a mismatch between the order of the input source arrays in the DAG and the function argument order for the operation. Since the DAG order is not stable, the operation now records the names of the input source arrays in the source_array_names variable.