### PR TITLE
Providing filesystem credentials through storage_options

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -290,6 +290,7 @@ def blockwise(
     spec = check_array_specs(arrays)
     if target_store is None:
         target_store = new_temp_path(name=name, spec=spec)
+    
     op = primitive_blockwise(
         func,
         out_ind,
@@ -308,6 +309,7 @@ def blockwise(
         extra_func_kwargs=extra_func_kwargs,
         fusable=fusable,
         num_input_blocks=num_input_blocks,
+        storage_options=spec.storage_options,
         **kwargs,
     )
     plan = Plan._new(
@@ -367,6 +369,7 @@ def general_blockwise(
         in_names=in_names,
         extra_func_kwargs=extra_func_kwargs,
         num_input_blocks=num_input_blocks,
+        storage_options=spec.storage_options,
         **kwargs,
     )
     plan = Plan._new(
@@ -746,6 +749,7 @@ def rechunk(x, chunks, target_store=None):
         reserved_mem=spec.reserved_mem,
         target_store=target_store,
         temp_store=temp_store,
+        storage_options=spec.storage_options,
     )
 
     from cubed.array_api import Array

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -290,7 +290,6 @@ def blockwise(
     spec = check_array_specs(arrays)
     if target_store is None:
         target_store = new_temp_path(name=name, spec=spec)
-    
     op = primitive_blockwise(
         func,
         out_ind,

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -130,6 +130,7 @@ def blockwise(
     extra_func_kwargs: Optional[Dict[str, Any]] = None,
     fusable: bool = True,
     num_input_blocks: Optional[Tuple[int, ...]] = None,
+    storage_options: Optional[Dict[str, Any]]=None,
     **kwargs,
 ):
     """Apply a function to multiple blocks from multiple inputs, expressed using concise indexing rules.
@@ -214,6 +215,7 @@ def blockwise(
         extra_func_kwargs=extra_func_kwargs,
         fusable=fusable,
         num_input_blocks=num_input_blocks,
+        storage_options=storage_options,        
         **kwargs,
     )
 
@@ -234,6 +236,7 @@ def general_blockwise(
     extra_func_kwargs: Optional[Dict[str, Any]] = None,
     fusable: bool = True,
     num_input_blocks: Optional[Tuple[int, ...]] = None,
+    storage_options: Optional[Dict[str, Any]]=None,
     **kwargs,
 ):
     """A more general form of ``blockwise`` that uses a function to specify the block
@@ -281,7 +284,7 @@ def general_blockwise(
         target_array = target_store
     else:
         target_array = lazy_zarr_array(
-            target_store, shape, dtype, chunks=chunksize, path=target_path
+            target_store, shape, dtype, chunks=chunksize, path=target_path, storage_options=storage_options
         )
 
     func_kwargs = extra_func_kwargs or {}

--- a/cubed/primitive/rechunk.py
+++ b/cubed/primitive/rechunk.py
@@ -1,7 +1,7 @@
 import itertools
 import math
 from math import ceil, prod
-from typing import Any, Iterable, Iterator, List, Optional, Sequence, Tuple
+from typing import Any, Iterable, Iterator, List, Optional, Sequence, Tuple, Dict
 
 import numpy as np
 
@@ -29,6 +29,7 @@ def rechunk(
     reserved_mem: int,
     target_store: T_Store,
     temp_store: Optional[T_Store] = None,
+    storage_options: Optional[Dict[str, Any]] = None,
 ) -> List[PrimitiveOperation]:
     """Change the chunking of an array, without changing its shape or dtype.
 
@@ -64,6 +65,7 @@ def rechunk(
         max_mem=rechunker_max_mem,
         target_store=target_store,
         temp_store=temp_store,
+        storage_options=storage_options,
     )
 
     intermediate = int_proxy.array
@@ -120,6 +122,7 @@ def _setup_array_rechunk(
     max_mem: int,
     target_store: T_Store,
     temp_store: Optional[T_Store] = None,
+    storage_options: Optional[Dict] = None,
 ) -> Tuple[CubedArrayProxy, CubedArrayProxy, CubedArrayProxy]:
     shape = source_array.shape
     source_chunks = source_array.chunks
@@ -140,7 +143,7 @@ def _setup_array_rechunk(
     int_chunks = tuple(int(x) for x in int_chunks)
     write_chunks = tuple(int(x) for x in write_chunks)
 
-    target_array = lazy_zarr_array(target_store, shape, dtype, chunks=target_chunks)
+    target_array = lazy_zarr_array(target_store, shape, dtype, chunks=target_chunks, storage_options=storage_options)
 
     if read_chunks == write_chunks:
         int_array = None
@@ -148,7 +151,7 @@ def _setup_array_rechunk(
         # do intermediate store
         if temp_store is None:
             raise ValueError("A temporary store location must be provided.")
-        int_array = lazy_zarr_array(temp_store, shape, dtype, chunks=int_chunks)
+        int_array = lazy_zarr_array(temp_store, shape, dtype, chunks=int_chunks, storage_options=storage_options)
 
     read_proxy = CubedArrayProxy(source_array, read_chunks)
     int_proxy = CubedArrayProxy(int_array, int_chunks)

--- a/cubed/primitive/rechunk.py
+++ b/cubed/primitive/rechunk.py
@@ -122,7 +122,7 @@ def _setup_array_rechunk(
     max_mem: int,
     target_store: T_Store,
     temp_store: Optional[T_Store] = None,
-    storage_options: Optional[Dict] = None,
+    storage_options: Optional[Dict[str, Any]] = None,
 ) -> Tuple[CubedArrayProxy, CubedArrayProxy, CubedArrayProxy]:
     shape = source_array.shape
     source_chunks = source_array.chunks

--- a/cubed/storage/zarr.py
+++ b/cubed/storage/zarr.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union
 
 import zarr
+import s3fs
 
 from cubed.types import T_DType, T_RegularChunks, T_Shape, T_Store
 
@@ -27,14 +28,18 @@ class LazyZarrArray:
         template = zarr.empty(
             shape, dtype=dtype, chunks=chunks, store=zarr.storage.MemoryStore()
         )
+        if "storage_options" in kwargs and kwargs["storage_options"]:
+            s3 = s3fs.S3FileSystem(**kwargs["storage_options"])
+            store = s3fs.S3Map(root=store, s3=s3, check=False)
+
         self.shape = template.shape
         self.dtype = template.dtype
         self.chunks = template.chunks
         self.nbytes = template.nbytes
-
         self.store = store
         self.path = path
         self.kwargs = kwargs
+        print(f'self.store: {self.store}')
 
     def create(self, mode: str = "w-") -> zarr.Array:
         """Create the Zarr array in storage.

--- a/cubed/storage/zarr.py
+++ b/cubed/storage/zarr.py
@@ -39,7 +39,6 @@ class LazyZarrArray:
         self.store = store
         self.path = path
         self.kwargs = kwargs
-        print(f'self.store: {self.store}')
 
     def create(self, mode: str = "w-") -> zarr.Array:
         """Create the Zarr array in storage.

--- a/cubed/storage/zarr.py
+++ b/cubed/storage/zarr.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, Dict, Any
 
 import zarr
 import s3fs
@@ -21,6 +21,7 @@ class LazyZarrArray:
         dtype: T_DType,
         chunks: T_RegularChunks,
         path: Optional[str] = None,
+        storage_options: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
         """Create a Zarr array lazily in memory."""
@@ -28,10 +29,9 @@ class LazyZarrArray:
         template = zarr.empty(
             shape, dtype=dtype, chunks=chunks, store=zarr.storage.MemoryStore()
         )
-        if "storage_options" in kwargs and kwargs["storage_options"]:
-            s3 = s3fs.S3FileSystem(**kwargs["storage_options"])
+        if storage_options:
+            s3 = s3fs.S3FileSystem(**storage_options)
             store = s3fs.S3Map(root=store, s3=s3, check=False)
-
         self.shape = template.shape
         self.dtype = template.dtype
         self.chunks = template.chunks
@@ -91,9 +91,10 @@ def lazy_zarr_array(
     dtype: T_DType,
     chunks: T_RegularChunks,
     path: Optional[str] = None,
+    storage_options: Optional[Dict[str, Any]]=None,
     **kwargs,
 ) -> LazyZarrArray:
-    return LazyZarrArray(store, shape, dtype, chunks, path=path, **kwargs)
+    return LazyZarrArray(store, shape, dtype, chunks, path=path, storage_options=storage_options, **kwargs)
 
 
 def open_if_lazy_zarr_array(array: T_ZarrArray) -> zarr.Array:


### PR DESCRIPTION
Fixes [#432](https://github.com/cubed-dev/cubed/issues/432#issue-2194715891). This allows to specify the credentials of a storage file system to Spec class. Needed for S3-compatible storage system such as minIO.