### PR TITLE
Implement virtual array indexing using ndindex

### DIFF
--- a/cubed/runtime/executors/modal.py
+++ b/cubed/runtime/executors/modal.py
@@ -38,6 +38,7 @@ else:
             "donfig",
             "fsspec",
             "mypy_extensions",  # for rechunker
+            "ndindex",
             "networkx",
             "pytest-mock",  # TODO: only needed for tests
             "s3fs",
@@ -52,6 +53,7 @@ else:
             "donfig",
             "fsspec",
             "mypy_extensions",  # for rechunker
+            "ndindex",
             "networkx",
             "pytest-mock",  # TODO: only needed for tests
             "gcsfs",

--- a/cubed/tests/runtime/test_modal.py
+++ b/cubed/tests/runtime/test_modal.py
@@ -23,6 +23,7 @@ image = modal.Image.debian_slim().pip_install(
         "donfig",
         "fsspec",
         "mypy_extensions",  # for rechunker
+        "ndindex",
         "networkx",
         "pytest-mock",  # TODO: only needed for tests
         "s3fs",

--- a/cubed/tests/test_indexing.py
+++ b/cubed/tests/test_indexing.py
@@ -23,8 +23,9 @@ def spec(tmp_path):
     ],
 )
 def test_int_array_index_1d(spec, ind):
-    a = xp.arange(12, chunks=(4,), spec=spec)
-    assert_array_equal(a[ind].compute(), np.arange(12)[ind])
+    a = xp.arange(12, chunks=(3,), spec=spec)
+    b = a.rechunk((4,))  # force materialization to test indexing against zarr
+    assert_array_equal(b[ind].compute(), np.arange(12)[ind])
 
 
 @pytest.mark.parametrize(
@@ -40,11 +41,12 @@ def test_int_array_index_1d(spec, ind):
 def test_int_array_index_2d(spec, ind):
     a = xp.asarray(
         [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]],
-        chunks=(2, 2),
+        chunks=(3, 3),
         spec=spec,
     )
+    b = a.rechunk((2, 2))  # force materialization to test indexing against zarr
     x = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
-    assert_array_equal(a[ind].compute(), x[ind])
+    assert_array_equal(b[ind].compute(), x[ind])
 
 
 def test_multiple_int_array_indexes(spec):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "donfig",
     "fsspec",
     "mypy_extensions", # for rechunker
+    "ndindex",
     "networkx != 2.8.3, != 2.8.4, != 2.8.5, != 2.8.6, != 2.8.7, != 2.8.8, != 3.0.*, != 3.1.*, != 3.2.*",
     "numpy >= 1.22",
     "tenacity",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ aiostream
 array-api-compat
 fsspec
 mypy_extensions # for rechunker
+ndindex
 networkx != 2.8.3, != 2.8.4, != 2.8.5, != 2.8.6, != 2.8.7, != 2.8.8, != 3.0.*, != 3.1.*, != 3.2.*
 numpy >= 1.22
 tenacity

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-matplotlib.*]
 ignore_missing_imports = True
+[mypy-ndindex.*]
+ignore_missing_imports = True
 [mypy-networkx.*]
 ignore_missing_imports = True
 [mypy-numpy.*]


### PR DESCRIPTION
The reason to do this is that it removes a dependency on an internal Zarr API (`BasicIndexer`). It adds a dependency on `ndeindex`, but it's lightweight, and will be used for #403 later.