### PR TITLE
Fix Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ Cubed is a distributed N-dimensional array library implemented in Python using b
 - Multiple serverless runtimes: Python (in-process), [Lithops](https://lithops-cloud.github.io/), [Modal](https://modal.com/), [Apache Beam](https://beam.apache.org/)
 - Integration with [Xarray](https://xarray.dev/) via [cubed-xarray](https://github.com/xarray-contrib/cubed-xarray)
 
-[Documentation](https://tomwhite.github.io/cubed)
+[Documentation](https://cubed-dev.github.io/cubed/)
+
+


### PR DESCRIPTION
Current link to Documentation at the bottom of the README gives a 404.

