### PR TITLE
Re-interpret 'fusable' to mean with predecessor operations

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -748,7 +748,7 @@ def map_direct(
         chunks=chunks,
         extra_source_arrays=args,
         extra_projected_mem=extra_projected_mem,
-        fusable=False,  # don't allow fusion since side inputs are not accounted for
+        fusable=False,  # don't allow fusion with predecessors since side inputs are not accounted for
         **kwargs,
     )
 

--- a/cubed/primitive/types.py
+++ b/cubed/primitive/types.py
@@ -38,7 +38,7 @@ class PrimitiveOperation:
     """The number of tasks needed to run this operation."""
 
     fusable: bool = True
-    """Whether this operation should be considered for fusion."""
+    """Whether this operation can be fused with predecessor operations."""
 
     write_chunks: Optional[T_RegularChunks] = None
     """The chunk size used by this operation."""


### PR DESCRIPTION
An operation like 'map_direct' which can read data across block boundaries from its inputs is marked with `fusable=False`, since it cannot be fused with predecessor operations. However, it is permitted for successor operations to fuse with `map_direct`, since they will operate on whole blocks.