### PR TITLE
Implement NumPy's `__array_function__` protocol for array methods that are not in the Array API Standard

### DIFF
--- a/cubed/nan_functions.py
+++ b/cubed/nan_functions.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from cubed.array_api.array_object import implements
 from cubed.array_api.dtypes import (
     _numeric_dtypes,
     _signed_integer_dtypes,
@@ -18,9 +19,12 @@ from cubed.core import reduction
 # https://github.com/data-apis/array-api/issues/621
 
 
-def nanmean(x, /, *, axis=None, keepdims=False, use_new_impl=True, split_every=None):
+@implements(np.nanmean)
+def nanmean(
+    x, /, *, axis=None, dtype=None, keepdims=False, use_new_impl=True, split_every=None
+):
     """Compute the arithmetic mean along the specified axis, ignoring NaNs."""
-    dtype = x.dtype
+    dtype = dtype or x.dtype
     intermediate_dtype = [("n", nxp.int64), ("total", nxp.float64)]
     return reduction(
         x,
@@ -61,6 +65,7 @@ def _nannumel(x, **kwargs):
     return nxp.sum(~(nxp.isnan(x)), **kwargs)
 
 
+@implements(np.nansum)
 def nansum(
     x, /, *, axis=None, dtype=None, keepdims=False, use_new_impl=True, split_every=None
 ):

--- a/cubed/pad.py
+++ b/cubed/pad.py
@@ -1,6 +1,13 @@
+import numpy as np
+
+from cubed.array_api.array_object import implements
 from cubed.array_api.manipulation_functions import concat
 
+# TODO: refactor once pad is standardized:
+# https://github.com/data-apis/array-api/issues/187
 
+
+@implements(np.pad)
 def pad(x, pad_width, mode=None, chunks=None):
     """Pad an array."""
     if len(pad_width) != x.ndim:

--- a/cubed/tests/test_nan_functions.py
+++ b/cubed/tests/test_nan_functions.py
@@ -11,9 +11,11 @@ def spec(tmp_path):
     return cubed.Spec(tmp_path, allowed_mem=100000)
 
 
-def test_nanmean(spec):
+@pytest.mark.parametrize("namespace", [cubed, np])
+def test_nanmean(spec, namespace):
     a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, xp.nan]], chunks=(2, 2), spec=spec)
-    b = cubed.nanmean(a)
+    b = namespace.nanmean(a)
+    assert isinstance(b, cubed.Array)
     assert_array_equal(
         b.compute(), np.nanmean(np.array([[1, 2, 3], [4, 5, 6], [7, 8, np.nan]]))
     )
@@ -26,9 +28,11 @@ def test_nanmean_allnan(spec):
     assert_array_equal(b.compute(), np.nanmean(np.array([np.nan])))
 
 
-def test_nansum(spec):
+@pytest.mark.parametrize("namespace", [cubed, np])
+def test_nansum(spec, namespace):
     a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, xp.nan]], chunks=(2, 2), spec=spec)
-    b = cubed.nansum(a)
+    b = namespace.nansum(a)
+    assert isinstance(b, cubed.Array)
     assert_array_equal(
         b.compute(), np.nansum(np.array([[1, 2, 3], [4, 5, 6], [7, 8, np.nan]]))
     )

--- a/cubed/tests/test_pad.py
+++ b/cubed/tests/test_pad.py
@@ -11,11 +11,15 @@ def spec(tmp_path):
     return cubed.Spec(tmp_path, allowed_mem=100000)
 
 
-def test_pad(spec):
+@pytest.mark.parametrize("namespace", [cubed, np])
+def test_pad(spec, namespace):
     an = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
     a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
-    b = cubed.pad(a, ((1, 0), (0, 0)), mode="symmetric")
+    # check that we can dispatch via the numpy namespace (via __array_function__)
+    # since pad is not yet a part of the Array API Standard
+    b = namespace.pad(a, ((1, 0), (0, 0)), mode="symmetric")
+    assert isinstance(b, cubed.Array)
     assert b.chunks == ((2, 2), (2, 1))
 
     assert_array_equal(b.compute(), np.pad(an, ((1, 0), (0, 0)), mode="symmetric"))


### PR DESCRIPTION
Namely nanmean, nansum, and pad.

This is a pragmatic way to get issues like #153 working until functions are standardized.