### PR TITLE
Fix case of Lithops 3.4.0 hanging

### DIFF
--- a/cubed/tests/utils.py
+++ b/cubed/tests/utils.py
@@ -14,7 +14,8 @@ LITHOPS_LOCAL_CONFIG = {
         "backend": "localhost",
         "storage": "localhost",
         "monitoring_interval": 0.1,
-    }
+    },
+    "localhost": {"version": 1},
 }
 
 ALL_EXECUTORS = [create_executor("single-threaded")]


### PR DESCRIPTION
Some test runs have been timing out and failing, e.g. https://github.com/cubed-dev/cubed/actions/runs/9312670412 was the first failure. This coincided with the release of [Lithops 3.4.0](https://github.com/lithops-cloud/lithops/releases/tag/3.4.0), and further debugging revealed that it was due to the new (v2) localhost backend.

The fix is to use the v1 backend.