### PR TITLE
Speed up tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,8 @@ jobs:
           PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
 
       - name: Run tests
+        env:
+          COVERAGE_CORE: sysmon
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
             pytest -v

--- a/cubed/tests/utils.py
+++ b/cubed/tests/utils.py
@@ -14,6 +14,7 @@ LITHOPS_LOCAL_CONFIG = {
         "backend": "localhost",
         "storage": "localhost",
         "monitoring_interval": 0.1,
+        "include_modules": None
     },
     "localhost": {"version": 1},
 }


### PR DESCRIPTION
Based on the discussion [here](https://github.com/cubed-dev/cubed/pull/456):
- Disable the Lithops `module_manager` to speed up tests in all the OS
- Speed up tests on python3.12 by setting `COVERAGE_CORE: sysmon`