### PR TITLE
Fail with NotImplementedError if backend Zarr is missing nchunks_initialized

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,4 +8,5 @@ omit =
     cubed/runtime/executors/dask*.py
     cubed/runtime/executors/lithops.py
     cubed/runtime/executors/modal*.py
+    cubed/storage/backends/tensorstore.py
     cubed/vendor/*

--- a/.github/workflows/tensorstore-tests.yml
+++ b/.github/workflows/tensorstore-tests.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Run tests
         run: |
-          # exclude tests that rely on the nchunks_initialized array attribute
-          pytest -k "not test_resume"
+          pytest -v
         env:
           CUBED_STORAGE_NAME: tensorstore

--- a/cubed/runtime/pipeline.py
+++ b/cubed/runtime/pipeline.py
@@ -27,6 +27,10 @@ def already_computed(
             target = nodes[output].get("target", None)
             if target is not None:
                 target = open_if_lazy_zarr_array(target)
+                if not hasattr(target, "nchunks_initialized"):
+                    raise NotImplementedError(
+                        f"Zarr array type {type(target)} does not support resume since it doesn't have a 'nchunks_initialized' property"
+                    )
                 # this check can be expensive since it has to list the directory to find nchunks_initialized
                 if target.ndim == 0 or target.nchunks_initialized != target.nchunks:
                     return False


### PR DESCRIPTION
This is true for TensorStore and Zarr v3 (currently).