### PR TITLE
Remove `max_tasks_per_child=1` limitation from processes executor

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,6 +1,7 @@
 name: Slow tests
 
 on:
+  pull_request:
   schedule:
     # Every weekday at 03:49 UTC, see https://crontab.guru/
     - cron: "49 3 * * 1-5"

--- a/cubed/runtime/executors/local.py
+++ b/cubed/runtime/executors/local.py
@@ -179,11 +179,19 @@ async def async_execute_dag(
     if spec is not None:
         check_runtime_memory(spec, max_workers)
     if use_processes:
+        max_tasks_per_child = kwargs.pop("max_tasks_per_child", None)
         context = multiprocessing.get_context("spawn")
         # max_tasks_per_child is only supported from Python 3.11
-        concurrent_executor = ProcessPoolExecutor(
-            max_workers=max_workers, mp_context=context, max_tasks_per_child=1
-        )
+        if max_tasks_per_child is None:
+            concurrent_executor = ProcessPoolExecutor(
+                max_workers=max_workers, mp_context=context
+            )
+        else:
+            concurrent_executor = ProcessPoolExecutor(
+                max_workers=max_workers,
+                mp_context=context,
+                max_tasks_per_child=max_tasks_per_child,
+            )
     else:
         concurrent_executor = ThreadPoolExecutor(max_workers=max_workers)
     try:

--- a/cubed/tests/utils.py
+++ b/cubed/tests/utils.py
@@ -1,5 +1,4 @@
 import platform
-import sys
 from typing import Iterable
 
 import networkx as nx
@@ -29,10 +28,8 @@ if platform.system() != "Windows":
     # ThreadsExecutor calls `peak_measured_mem` which is not supported on Windows
     ALL_EXECUTORS.append(create_executor("threads"))
 
-    # ProcessesExecutor uses an API available from 3.11 onwards (max_tasks_per_child)
-    if sys.version_info >= (3, 11):
-        ALL_EXECUTORS.append(create_executor("processes"))
-        MAIN_EXECUTORS.append(create_executor("processes"))
+    ALL_EXECUTORS.append(create_executor("processes"))
+    MAIN_EXECUTORS.append(create_executor("processes"))
 
 try:
     ALL_EXECUTORS.append(create_executor("beam"))


### PR DESCRIPTION
I originally imposed this constraint in #411 since it allowed a convenient way to test that tasks never used more memory than projected (see test_mem_utilization.py).

However, on re-running the benchmark in https://github.com/cubed-dev/cubed/issues/492#issuecomment-2238908343 I saw that the processes never exceeded `allowed_mem`, and also the tests in this PR also check that invariant for a variety of workloads.

This also means that we can use `processes` on Python < 3.11.