### PR TITLE
Update CUBED_CONFIG path in example README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -37,14 +37,14 @@ The `add-asarray.py` script is a small example that adds two small 4x4 arrays to
 Export `CUBED_CONFIG` as described in the set up instructions, then run the script. This is for running on the local machine using the `processes` executor:
 
 ```shell
-export CUBED_CONFIG=$(pwd)/processes
+export CUBED_CONFIG=$(pwd)/processes/cubed.yaml
 python add-asarray.py
 ```
 
 This is for Lithops on AWS:
 
 ```shell
-export CUBED_CONFIG=$(pwd)/lithops/aws
+export CUBED_CONFIG=$(pwd)/lithops/aws/cubed.yaml
 python add-asarray.py
 ```
 


### PR DESCRIPTION
While testing cubed, I was experiencing a lot of new-user environment issues. One issue was that I'd setup `CUBED_CONFIG` to point to a directory rather than a `yaml` file, as is shown in README example. However, I was hacking on a problem and had several `yaml` files that I was testing. Depending on my naming convention, different files might get picked up as my `CUBED_CONFIG`. A better practice is to explicitly name the file in the README example.

Specifically, like

```shell
export CUBED_CONFIG=$(pwd)/processes/cubed.yaml
python add-asarray.py
```