### PR TITLE
Adding `compile_function` as execute option.

### DIFF
--- a/.github/workflows/jax-tests.yml
+++ b/.github/workflows/jax-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e '.[test]' 'jax[cpu]'
+          python -m pip install -e '.[test]' 'jax[cpu]' 'numba'
           python -m pip uninstall -y lithops  # tests don't run on Lithops
 
       - name: Run tests

--- a/.github/workflows/jax-tests.yml
+++ b/.github/workflows/jax-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e '.[test]' 'jax[cpu]' 'numba'
+          python -m pip install -e '.[test]' 'jax[cpu]' numba
           python -m pip uninstall -y lithops  # tests don't run on Lithops
 
       - name: Run tests

--- a/.github/workflows/jax-tests.yml
+++ b/.github/workflows/jax-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e '.[test]' 'jax[cpu]' numba
+          python -m pip install -e '.[test]' 'jax[cpu]'
           python -m pip uninstall -y lithops  # tests don't run on Lithops
 
       - name: Run tests

--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -204,7 +204,7 @@ class Plan:
         return dag
 
     def _compile_blockwise(self, dag, compile_function: Decorator) -> nx.MultiDiGraph:
-        """JIT-compiles the functions from all blockwise ops by mutating the input dag."""
+        """Compiles functions from all blockwise ops by mutating the input dag."""
         # Recommended: make a copy of the dag before calling this function.
 
         compile_with_config = 'config' in inspect.getfullargspec(compile_function).kwonlyargs

--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -31,7 +31,7 @@ CONTEXT_ID = f"cubed-{datetime.now().strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4()}"
 # Delete local context dirs when Python exits
 CONTEXT_DIRS = set()
 
-Decorator = Callable[[Callable], Callable]
+Decorator = Callable
 
 
 def delete_on_exit(context_dir: str) -> None:

--- a/cubed/tests/test_executor_features.py
+++ b/cubed/tests/test_executor_features.py
@@ -329,13 +329,6 @@ try:
     if 'jax' in os.environ.get('CUBED_BACKEND_ARRAY_API_MODULE', ''):
         from jax import jit as jax_jit
         COMPILE_FUNCTIONS.append(jax_jit)
-
-        def aot(func, *, config=None):
-            # TODO(alxmrs): implement lowering
-            return jax_jit(func)
-
-        COMPILE_FUNCTIONS.append(aot)
-
 except ModuleNotFoundError:
     pass
 
@@ -357,12 +350,10 @@ def test_compilation_can_fail(spec, executor):
     a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
     b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
     c = xp.add(a, b)
-    try:
+    with pytest.raises(NotImplementedError) as excinfo:
         c.compute(executor=executor, compile_function=compile_function)
-        assert False, "Compile function was not called."
-    except NotImplementedError as e:
-        assert True, "Compile function was applied."
-        assert "add" in str(e), "Compile function was applied to add operation."
+    
+    assert "add" in str(excinfo.value), "Compile function was applied to add operation."
 
 
 def test_compilation_with_config_can_fail(spec, executor):
@@ -372,9 +363,7 @@ def test_compilation_with_config_can_fail(spec, executor):
     a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
     b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
     c = xp.add(a, b)
-    try:
+    with pytest.raises(NotImplementedError) as excinfo:
         c.compute(executor=executor, compile_function=compile_function)
-        assert False, "Compile function was not called."
-    except NotImplementedError as e:
-        assert "add" in str(e), "Compile function was applied to add operation."
-        assert "BlockwiseSpec" in str(e), "Compile function was applied with a config argument."
+        
+    assert "BlockwiseSpec" in str(excinfo.value), "Compile function was applied with a config argument."

--- a/cubed/tests/test_executor_features.py
+++ b/cubed/tests/test_executor_features.py
@@ -363,3 +363,18 @@ def test_compilation_can_fail(spec, executor):
     except NotImplementedError as e:
         assert True, "Compile function was applied."
         assert "add" in str(e), "Compile function was applied to add operation."
+
+
+def test_compilation_with_config_can_fail(spec, executor):
+    def compile_function(func, *, config=None):
+        raise NotImplementedError(f"Cannot compile {func} with {config}")
+
+    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
+    b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
+    c = xp.add(a, b)
+    try:
+        c.compute(executor=executor, compile_function=compile_function)
+        assert False, "Compile function was not called."
+    except NotImplementedError as e:
+        assert "add" in str(e), "Compile function was applied to add operation."
+        assert "BlockwiseSpec" in str(e), "Compile function was applied with a config argument."


### PR DESCRIPTION
This allows users to use jit or aot compilation during the dag finalization process within executors. It should work straightforwardly on jax/numba style jit compilation. It's possible, but maybe ugly, to perform jax-aot-style compilation.

This should help make progress towards #304.

(Note to reviewer: I realized this could be merged ahead of #508, so I pulled it out into a non-dependent PR).