### PR TITLE
Add `raise_if_computes` for testing

### DIFF
--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -24,6 +24,10 @@ def gensym(name="array"):
     return f"{name}-{sym_counter:03}"
 
 
+# see cubed.testing
+compute_should_raise = False
+
+
 # type representing either a CoreArray or a public-facing Array
 T_ChunkedArray = TypeVar("T_ChunkedArray", bound="CoreArray")
 
@@ -269,6 +273,8 @@ def compute(
         If True, intermediate arrays that have already been computed won't be
         recomputed. Default is False.
     """
+    if compute_should_raise:
+        raise RuntimeError("'compute' was called")
     spec = check_array_specs(arrays)  # guarantees all arrays have same spec
     plan = arrays_to_plan(*arrays)
     if executor is None:

--- a/cubed/testing.py
+++ b/cubed/testing.py
@@ -1,0 +1,13 @@
+from contextlib import contextmanager
+
+from cubed.core import array
+
+
+@contextmanager
+def raise_if_computes():
+    """Returns a context manager for testing that ``compute`` is not called."""
+    array.compute_should_raise = True
+    try:
+        yield
+    finally:
+        array.compute_should_raise = False

--- a/cubed/tests/test_testing.py
+++ b/cubed/tests/test_testing.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+import cubed.array_api as xp
+from cubed.testing import raise_if_computes
+
+
+def test_raise_if_computes():
+    # shouldn't raise since compute has not been called
+    with raise_if_computes():
+        a = xp.ones((3, 3), chunks=(2, 2))
+        b = xp.negative(a)
+
+    # should raise since compute is called
+    with pytest.raises(RuntimeError):
+        with raise_if_computes():
+            b.compute()
+
+    # shouldn't raise since we are outside the context manager
+    assert_array_equal(b.compute(), -np.ones((3, 3)))


### PR DESCRIPTION
Fixes #310

This is useful for xarray testing.

I had hoped to be able to implement this by writing an executor that raises  when its `execute_dag` method is called - but that doesn't work. The problem is that the second part of this test fails, since `b`'s `spec` object contains the `raise-if-computes` executor since it was created within the context manager. Even though `compute` is called outside the context manager, the executor is still set on the `spec`, so that is what is used.

```python
def test_raise_if_computes():
    # shouldn't raise since compute has not been called
    with raise_if_computes():
        a = xp.ones((3, 3), chunks=(2, 2))
        b = xp.negative(a)

    # shouldn't raise since we are outside the context manager
    assert_array_equal(b.compute(), -np.ones((3, 3)))
```

I'm not sure that changing this is the right thing to do, hence this PR which does things a bit more directly.