### PR TITLE
Rechunk where dict has missing axes

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -756,6 +756,16 @@ def map_direct(
 
 
 def rechunk(x, chunks, target_store=None):
+    if isinstance(chunks, dict):
+        chunks = {validate_axis(c, x.ndim): v for c, v in chunks.items()}
+        for i in range(x.ndim):
+            if i not in chunks:
+                chunks[i] = x.chunks[i]
+            elif chunks[i] is None:
+                chunks[i] = x.chunks[i]
+    if isinstance(chunks, (tuple, list)):
+        chunks = tuple(lc if lc is not None else rc for lc, rc in zip(chunks, x.chunks))
+
     normalized_chunks = normalize_chunks(chunks, x.shape, dtype=x.dtype)
     if x.chunks == normalized_chunks:
         return x


### PR DESCRIPTION
When rechunking with a dict that doesn't contain all axes, then the chunking should be unchanged for those axes that are missing.

In particular, `a.rechunk({})` should be a no-op.

This is consistent with Dask (https://github.com/dask/dask/issues/11261) and Xarray https://github.com/pydata/xarray/pull/9286)