### PR TITLE
Fix Array API Tests 

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: data-apis/array-api-tests
+          ref: 'db95e67b29235249e5776ca2b6bb4e77117e0690'  # Latest commit as of 2024-08-08
           path: array-api-tests
           submodules: "true"
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The latest runs have been failing with e.g. `ERROR array_api_tests/test_array_object.py - TypeError: unsupported operand type(s) for |: '_GenericAlias' and 'NoneType'`, see https://github.com/cubed-dev/cubed/actions/runs/10631284435/job/29471855766.

This looks like it's because we are running on Python 3.9, and [this commit](https://github.com/data-apis/array-api-tests/commit/bef0ea392d0b3b19b13c9894cf28aec5bc505fb8) added a Python 3.10 type change.

I tried updating to Python 3.11, but that pulled in the new NumPy 2.1.0 which caused another error.

So I'm going to pin the version of array_api_tests that we run against for now.