### PR TITLE
Fail during planning if map_blocks drop_axis is for a chunked dimension

### DIFF
--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -687,6 +687,15 @@ def make_blockwise_key_function(
         False,
     )
 
+    for axes, (arg, _) in zip(concat_axes, argpairs):
+        for ax in axes:
+            if numblocks[arg][ax] > 1:
+                raise ValueError(
+                    f"Cannot have multiple chunks in dropped axis {ax}. "
+                    "To fix, use a reduction after calling map_blocks "
+                    "without specifying drop_axis, or rechunk first."
+                )
+
     def key_function(out_key):
         out_coords = out_key[1:]
 

--- a/cubed/tests/primitive/test_blockwise.py
+++ b/cubed/tests/primitive/test_blockwise.py
@@ -266,11 +266,11 @@ def test_make_blockwise_key_function_contract():
     func = lambda x: 0
 
     key_fn = make_blockwise_key_function(
-        func, "z", "ik", "x", "ij", "y", "jk", numblocks={"x": (2, 2), "y": (2, 2)}
+        func, "z", "ik", "x", "ij", "y", "jk", numblocks={"x": (2, 1), "y": (1, 2)}
     )
 
     graph = make_blockwise_graph(
-        func, "z", "ik", "x", "ij", "y", "jk", numblocks={"x": (2, 2), "y": (2, 2)}
+        func, "z", "ik", "x", "ij", "y", "jk", numblocks={"x": (2, 1), "y": (1, 2)}
     )
     check_consistent_with_graph(key_fn, graph)
 
@@ -290,10 +290,10 @@ def test_make_blockwise_key_function_contract_0d():
     func = lambda x: 0
 
     key_fn = make_blockwise_key_function(
-        func, "z", "", "x", "ij", numblocks={"x": (2, 2)}
+        func, "z", "", "x", "ij", numblocks={"x": (1, 1)}
     )
 
-    graph = make_blockwise_graph(func, "z", "", "x", "ij", numblocks={"x": (2, 2)})
+    graph = make_blockwise_graph(func, "z", "", "x", "ij", numblocks={"x": (1, 1)})
     check_consistent_with_graph(key_fn, graph)
 
 


### PR DESCRIPTION
Cubed does not automatically concatenate chunks in blockwise operations (by design - since it can lead to large memory usage), and will fail in this situation. This PR makes the failure happen during planning rather than during computation, and improves the error message.

Related: https://github.com/sgkit-dev/sgkit/pull/1254#issuecomment-2333865855