### PR TITLE
Zarr v3 now requires at least Python 3.11

### DIFF
--- a/.github/workflows/zarr-v3-tests.yml
+++ b/.github/workflows/zarr-v3-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
See https://github.com/zarr-developers/zarr-python/pull/2217