### PR TITLE
Use `general_blockwise` in case of chunk-aligned selections in `index`

### DIFF
--- a/cubed/tests/test_mem_utilization.py
+++ b/cubed/tests/test_mem_utilization.py
@@ -85,6 +85,15 @@ def test_index(tmp_path, spec, executor):
 
 
 @pytest.mark.slow
+def test_index_chunk_aligned(tmp_path, spec, executor):
+    a = cubed.random.random(
+        (10000, 10000), chunks=(5000, 5000), spec=spec
+    )  # 200MB chunks
+    b = a[0:5000, :]
+    run_operation(tmp_path, executor, "index_chunk_aligned", b)
+
+
+@pytest.mark.slow
 def test_index_step(tmp_path, spec, executor):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec

--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from functools import partial
 from itertools import islice
 from math import prod
-from operator import add
+from operator import add, mul
 from pathlib import Path
 from posixpath import join
 from typing import Dict, Tuple, Union, cast
@@ -18,6 +18,7 @@ from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
 import numpy as np
 import tlz as toolz
+from toolz import reduce
 
 from cubed.backend_array_api import namespace as nxp
 from cubed.types import T_DType, T_RectangularChunks, T_RegularChunks, T_Shape
@@ -39,6 +40,11 @@ def chunk_memory(arr) -> int:
         arr.dtype,
         to_chunksize(normalize_chunks(arr.chunks, shape=arr.shape, dtype=arr.dtype)),
     )
+
+
+def array_size(shape: T_Shape) -> int:
+    """Number of elements in an array."""
+    return reduce(mul, shape, 1)
 
 
 def offset_to_block_id(offset: int, numblocks: Tuple[int, ...]) -> Tuple[int, ...]:


### PR DESCRIPTION
This allows the optimizer to perform fusion, which is not the case with the existing `map_direct` implementation.