### PR TITLE
Support `block_id` for `general_blockwise` functions

### DIFF
--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -147,6 +147,10 @@ def to_chunksize(chunkset: T_RectangularChunks) -> T_RegularChunks:
     return tuple(max(c[0], 1) for c in chunkset)
 
 
+def numblocks(chunks: T_RectangularChunks) -> Tuple[int, ...]:
+    return tuple(map(len, chunks))
+
+
 @dataclass
 class StackSummary:
     """Like Python's ``FrameSummary``, but with module information."""


### PR DESCRIPTION
This adds the `block_id` feature in `map_blocks` and `map_direct` to `general_blockwise`, making it easier to move from `map_direct` to `general_blockwise` (see #464).