### PR TITLE
Map nested improvements

### DIFF
--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -108,13 +108,10 @@ def get_results_in_different_scope(out_coords: List[int], *, config: BlockwiseSp
     out_coords_tuple = tuple(out_coords)
 
     # get array chunks for input keys, preserving any nested list structure
-    args = []
     get_chunk_config = partial(get_chunk, config=config)
     out_key = ("out",) + out_coords_tuple  # array name is ignored by key_function
-    in_keys = config.key_function(out_key)
-    for in_key in in_keys:
-        arg = map_nested(get_chunk_config, in_key)
-        args.append(arg)
+    name_chunk_inds = list(config.key_function(out_key))
+    args = map_nested(get_chunk_config, name_chunk_inds)
 
     return config.function(*args)
 

--- a/cubed/tests/test_utils.py
+++ b/cubed/tests/test_utils.py
@@ -135,7 +135,9 @@ def test_map_nested_iterators():
     out = map_nested(inc, iter([1, 2]))
     assert isinstance(out, map)
     assert count == 0
-    assert list(out) == [2, 3]
+    assert next(out) == 2
+    assert count == 1
+    assert next(out) == 3
     assert count == 2
 
     # reset count
@@ -148,7 +150,9 @@ def test_map_nested_iterators():
     out = out[0]
     assert isinstance(out, map)
     assert count == 0
-    assert list(out) == [2, 3]
+    assert next(out) == 2
+    assert count == 1
+    assert next(out) == 3
     assert count == 2
 
     # reset count
@@ -161,12 +165,16 @@ def test_map_nested_iterators():
     out0 = out[0]
     assert isinstance(out0, map)
     assert count == 0
-    assert list(out0) == [2, 3]
+    assert next(out0) == 2
+    assert count == 1
+    assert next(out0) == 3
     assert count == 2
     out1 = out[1]
     assert isinstance(out1, map)
     assert count == 2
-    assert list(out1) == [4, 5]
+    assert next(out1) == 4
+    assert count == 3
+    assert next(out1) == 5
     assert count == 4
 
 


### PR DESCRIPTION
This change removes a for loop in `apply_blockwise` by using `map_nested` on the top-level input keys. It doesn't change the behaviour, but will make it possible in the future to allow inputs to be retrieved in parallel.