### PR TITLE
Change default `max_total_num_input_blocks` to 10

### DIFF
--- a/cubed/core/optimization.py
+++ b/cubed/core/optimization.py
@@ -11,6 +11,9 @@ from cubed.primitive.blockwise import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_MAX_TOTAL_SOURCE_ARRAYS = 4
+DEFAULT_MAX_TOTAL_NUM_INPUT_BLOCKS = 10
+
 
 def simple_optimize_dag(dag, array_names=None):
     """Apply map blocks fusion."""
@@ -154,8 +157,8 @@ def can_fuse_predecessors(
     name,
     *,
     array_names=None,
-    max_total_source_arrays=4,
-    max_total_num_input_blocks=None,
+    max_total_source_arrays=DEFAULT_MAX_TOTAL_SOURCE_ARRAYS,
+    max_total_num_input_blocks=DEFAULT_MAX_TOTAL_NUM_INPUT_BLOCKS,
     always_fuse=None,
     never_fuse=None,
 ):
@@ -242,8 +245,8 @@ def fuse_predecessors(
     name,
     *,
     array_names=None,
-    max_total_source_arrays=4,
-    max_total_num_input_blocks=None,
+    max_total_source_arrays=DEFAULT_MAX_TOTAL_SOURCE_ARRAYS,
+    max_total_num_input_blocks=DEFAULT_MAX_TOTAL_NUM_INPUT_BLOCKS,
     always_fuse=None,
     never_fuse=None,
 ):
@@ -297,8 +300,8 @@ def multiple_inputs_optimize_dag(
     dag,
     *,
     array_names=None,
-    max_total_source_arrays=4,
-    max_total_num_input_blocks=None,
+    max_total_source_arrays=DEFAULT_MAX_TOTAL_SOURCE_ARRAYS,
+    max_total_num_input_blocks=DEFAULT_MAX_TOTAL_NUM_INPUT_BLOCKS,
     always_fuse=None,
     never_fuse=None,
 ):

--- a/docs/user-guide/optimization.md
+++ b/docs/user-guide/optimization.md
@@ -112,9 +112,9 @@ e.visualize(optimize_function=opt_fn)
 
 The `max_total_num_input_blocks` argument to `multiple_inputs_optimize_dag` specifies the maximum number of input blocks (chunks) that are allowed in the fused operation.
 
-Again, this is to limit the number of reads that an individual task must perform. The default is `None`, which means that operations are fused only if they have the same number of tasks. If set to an integer, then this limitation is removed, and tasks with a different number of tasks will be fused - as long as the total number of input blocks does not exceed the maximum. This setting is useful for reductions, and can be set using `functools.partial`:
+Again, this is to limit the number of reads that an individual task must perform. If set to `None`, operations are fused only if they have the same number of tasks. If set to an integer (the default is 10), then tasks with a different number of tasks will be fused - as long as the total number of input blocks does not exceed the maximum. This setting is useful for reductions, and can be changed using `functools.partial`:
 
 ```python
-opt_fn = partial(multiple_inputs_optimize_dag, max_total_num_input_blocks=10)
+opt_fn = partial(multiple_inputs_optimize_dag, max_total_num_input_blocks=20)
 e.visualize(optimize_function=opt_fn)
 ```


### PR DESCRIPTION
To allow operations to be fused as long as the total number of input blocks does not exceed this number.

Previously, the default was None, which meant operations were fused only if they had the same number of tasks.