### PR TITLE
Remove direct dependency on fsspec

### DIFF
--- a/cubed/runtime/executors/modal.py
+++ b/cubed/runtime/executors/modal.py
@@ -36,7 +36,6 @@ else:
         [
             "array-api-compat",
             "donfig",
-            "fsspec",
             "mypy_extensions",  # for rechunker
             "ndindex",
             "networkx",
@@ -52,7 +51,6 @@ else:
         [
             "array-api-compat",
             "donfig",
-            "fsspec",
             "mypy_extensions",  # for rechunker
             "ndindex",
             "networkx",

--- a/cubed/tests/runtime/test_modal.py
+++ b/cubed/tests/runtime/test_modal.py
@@ -21,7 +21,6 @@ image = modal.Image.debian_slim().pip_install(
     [
         "array-api-compat",
         "donfig",
-        "fsspec",
         "mypy_extensions",  # for rechunker
         "ndindex",
         "networkx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "array-api-compat",
     "cloudpickle",
     "donfig",
-    "fsspec",
     "mypy_extensions", # for rechunker
     "ndindex",
     "networkx != 2.8.3, != 2.8.4, != 2.8.5, != 2.8.6, != 2.8.7, != 2.8.8, != 3.0.*, != 3.1.*, != 3.2.*",


### PR DESCRIPTION
It is not used directly in Cubed, and Zarr has it as a transitive dependency.