### PR TITLE
Change `chunk_shape` back to `chunks` for Zarr v3

### DIFF
--- a/cubed/storage/backends/zarr_python_v3.py
+++ b/cubed/storage/backends/zarr_python_v3.py
@@ -62,6 +62,6 @@ def open_zarr_v3_array(
                 field,
                 shape=shape,
                 dtype=field_dtype,
-                chunk_shape=chunks,
+                chunks=chunks,
             )
     return ret


### PR DESCRIPTION
To fix failures in https://github.com/cubed-dev/cubed/actions/workflows/zarr-v3-tests.yml due to upstream Zarr changes