### PR TITLE
Fix tooltips for SVGs generated by `visualize()` in Jupyter notebooks

### DIFF
--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -473,7 +473,7 @@ class Plan:
             import IPython.display as display
 
             if format == "svg":
-                return display.SVG(filename=full_filename)
+                return display.HTML(filename=full_filename)
         except ImportError:
             # Can't return a display object if no IPython.
             pass


### PR DESCRIPTION
See https://github.com/jupyter/notebook/issues/7114 for discussion of the problem