### PR TITLE
Allow nan functions to work with xarray

### DIFF
--- a/cubed/array/nan_functions.py
+++ b/cubed/array/nan_functions.py
@@ -8,9 +8,9 @@ from cubed.core import reduction
 # https://github.com/data-apis/array-api/issues/621
 
 
-def nanmean(x, /, *, axis=None, keepdims=False, split_every=None):
+def nanmean(x, /, *, axis=None, dtype=None, keepdims=False, split_every=None):
     """Compute the arithmetic mean along the specified axis, ignoring NaNs."""
-    dtype = x.dtype
+    dtype = dtype or x.dtype
     intermediate_dtype = [("n", nxp.int64), ("total", nxp.float64)]
     return reduction(
         x,

--- a/cubed/array_api/array_object.py
+++ b/cubed/array_api/array_object.py
@@ -367,9 +367,9 @@ class Array(CoreArray):
             "2023.12",
         ):
             raise ValueError(f"Unrecognized array API version: {api_version!r}")
-        import cubed.array_api as array_api
+        import cubed
 
-        return array_api
+        return cubed
 
     def __bool__(self, /):
         if self.ndim != 0:


### PR DESCRIPTION
Fixes #153

I missed https://github.com/pydata/xarray/pull/9798, which changes Xarray duck array ops to call `nanmean`, `nansum` etc on the array namespace. So instead of #475, we can just make sure that the nan functions are in the namespace returned by `__array_namespace__`, which should just be the top-level `cubed` namespace (following #473).