### PR TITLE
Mem utilization tests fail on zarr-python v3

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
+        zarr: ["<3", ">3"]
 
     steps:
       - name: Checkout source
@@ -41,6 +42,10 @@ jobs:
       - name: Install
         run: |
           python -m pip install -e .[test] memray
+
+      - name: Install zarr${{ matrix.zarr }}
+        run: |
+          python -m pip install -U 'zarr${{ matrix.zarr }}'
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This updates the slow tests (that run test_mem_utilization.py) to run on both zarr-python v2 and v3.