### PR TITLE
Remove new_axis from map_overlap kwargs

### DIFF
--- a/cubed/array/overlap.py
+++ b/cubed/array/overlap.py
@@ -56,6 +56,9 @@ def map_overlap(
 
     depth = coerce(args, depth, coerce_depth)
     boundary = coerce(args, boundary, coerce_boundary)
+    new_axis = kwargs.pop("new_axis", None)
+    if new_axis is not None:
+        raise NotImplementedError("new_axis is not supported in map_overlap")
 
     x = args[0]  # TODO: support multiple input arrays
 


### PR DESCRIPTION
Needed to fix test failures in https://github.com/sgkit-dev/sgkit/actions/workflows/cubed.yml