### PR TITLE
Fix doc build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Build and Commit
         id: deployment


### PR DESCRIPTION
"Ubuntu 20.04 LTS runner will be removed on 2025-04-15": https://github.com/cubed-dev/cubed/actions/runs/15594637855