### PR TITLE
Drop Python 3.10

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout Cubed

--- a/.github/workflows/beam-tests.yml
+++ b/.github/workflows/beam-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/dask-tests.yml
+++ b/.github/workflows/dask-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/jax-tests.yml
+++ b/.github/workflows/jax-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/lithops-tests.yml
+++ b/.github/workflows/lithops-tests.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-13"]
-        python-version: ["3.10"]
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,6 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install pypa/build
         run: >-
           python3 -m

--- a/.github/workflows/scale-tests.yml.disabled
+++ b/.github/workflows/scale-tests.yml.disabled
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-13", "windows-latest"]
-        python-version: ["3.10"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.11"]
         include:
           - os: "ubuntu-latest"
             python-version: "3.12"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,7 @@ Contributions to Cubed are very welcome. Please head over to [GitHub](https://gi
 Create an environment with
 
 ```shell
-conda create --name cubed python=3.10
+conda create --name cubed python=3.11
 conda activate cubed
 pip install -r requirements.txt
 pip install -e .

--- a/examples/dataflow/README.md
+++ b/examples/dataflow/README.md
@@ -9,7 +9,7 @@
 1. Install a Python environment with the basic package requirements:
 
 ```shell
-conda create --name cubed-dataflow-examples -y python=3.10
+conda create --name cubed-dataflow-examples -y python=3.11
 conda activate cubed-dataflow-examples
 pip install -r requirements.txt
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "aiostream",
     "array-api-compat",


### PR DESCRIPTION
Zarr 3 no longer supports Python 3.10, and it's outside the SPEC 0 support window.