### PR TITLE
Allow use of obstore as a Zarr store

### DIFF
--- a/cubed/storage/backends/zarr_python_v3.py
+++ b/cubed/storage/backends/zarr_python_v3.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional
 
 import zarr
@@ -39,6 +40,22 @@ def open_zarr_v3_array(
     path: Optional[str] = None,
     **kwargs,
 ):
+    # use obstore if requested
+    storage_options = kwargs.get("storage_options", None)
+    if storage_options is not None and storage_options.get("use_obstore", False):
+        import obstore as obs
+        from zarr.storage import ObjectStore
+
+        if isinstance(store, str):
+            if "://" not in store:
+                p = Path(store)
+                store = ObjectStore(obs.store.from_url(p.as_uri(), mkdir=True))
+            else:
+                store = ObjectStore(obs.store.from_url(store))
+        elif isinstance(store, Path):
+            p = store
+            store = ObjectStore(obs.store.from_url(p.as_uri(), mkdir=True))
+
     if isinstance(chunks, int):
         chunks = (chunks,)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-numpy.*]
 ignore_missing_imports = True
+[mypy-obstore.*]
+ignore_missing_imports = True
 [mypy-pandas.*]
 ignore_missing_imports = True
 [mypy-psutil.*]


### PR DESCRIPTION
Fixes #715 

All tests pass with 

```CUBED_SPEC__STORAGE_OPTIONS__USE_OBSTORE=True pytest```

But note this doesn't use obstore for all tests, since many have hardcoded `Spec` objects.