### PR TITLE
Change list of output arrays in BlockwiseSpec to a map

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -306,6 +306,7 @@ def blockwise(
         reserved_mem=spec.reserved_mem,
         extra_projected_mem=extra_projected_mem,
         target_store=target_store,
+        target_name=name,
         target_path=target_path,
         storage_options=spec.storage_options,
         compressor=spec.zarr_compressor,
@@ -314,7 +315,6 @@ def blockwise(
         chunks=_chunks,
         new_axes=new_axes,
         in_names=in_names,
-        out_name=name,
         buffer_copies=buffer_copies,
         extra_func_kwargs=extra_func_kwargs,
         fusable_with_predecessors=fusable_with_predecessors,
@@ -454,10 +454,12 @@ def _general_blockwise(
             ts if ts is not None else new_temp_path(name=n, spec=spec)
             for n, ts in zip(name, target_stores)
         ]
+        target_names = name
     else:  # single output
         name = gensym()
         if target_stores is None:
             target_stores = [new_temp_path(name=name, spec=spec)]
+        target_names = [name]
 
     op = primitive_general_blockwise(
         func,
@@ -468,6 +470,7 @@ def _general_blockwise(
         extra_projected_mem=extra_projected_mem,
         buffer_copies=buffer_copies,
         target_stores=target_stores,
+        target_names=target_names,
         target_paths=target_paths,
         storage_options=spec.storage_options,
         compressor=spec.zarr_compressor,

--- a/cubed/tests/primitive/test_blockwise.py
+++ b/cubed/tests/primitive/test_blockwise.py
@@ -40,6 +40,7 @@ def test_blockwise(tmp_path, executor, reserved_mem):
         allowed_mem=allowed_mem,
         reserved_mem=reserved_mem,
         target_store=target_store,
+        target_name="target",
         shape=(3, 3),
         dtype=int,
         chunks=(2, 2),
@@ -70,7 +71,7 @@ def test_blockwise(tmp_path, executor, reserved_mem):
     assert_array_equal(res[:], np.outer([0, 1, 2], [10, 50, 100]))
 
 
-def _permute_dims(x, /, axes, allowed_mem, reserved_mem, target_store):
+def _permute_dims(x, /, axes, allowed_mem, reserved_mem, target_store, target_name):
     # From dask transpose
     if axes:
         if len(axes) != x.ndim:
@@ -86,6 +87,7 @@ def _permute_dims(x, /, axes, allowed_mem, reserved_mem, target_store):
         allowed_mem=allowed_mem,
         reserved_mem=reserved_mem,
         target_store=target_store,
+        target_name=target_name,
         shape=x.shape,
         dtype=x.dtype,
         chunks=x.chunks,
@@ -109,6 +111,7 @@ def test_blockwise_with_args(tmp_path, executor):
         allowed_mem=allowed_mem,
         reserved_mem=0,
         target_store=target_store,
+        target_name="target",
     )
 
     assert op.target_array.shape == (3, 3)
@@ -160,6 +163,7 @@ def test_blockwise_allowed_mem_exceeded(tmp_path, reserved_mem):
             allowed_mem=allowed_mem,
             reserved_mem=reserved_mem,
             target_store=target_store,
+            target_name="target",
             shape=(3, 3),
             dtype=np.int64,
             chunks=(2, 2),
@@ -204,6 +208,7 @@ def test_general_blockwise(tmp_path, executor):
         allowed_mem=allowed_mem,
         reserved_mem=0,
         target_stores=[target_store],
+        target_names=["target"],
         shapes=[(20,)],
         dtypes=[int],
         chunkss=[(6,)],
@@ -252,6 +257,7 @@ def test_blockwise_multiple_outputs(tmp_path, executor):
         allowed_mem=allowed_mem,
         reserved_mem=0,
         target_stores=[target_store1, target_store2],
+        target_names=["target1", "target2"],
         shapes=[(3, 3), (3, 3)],
         dtypes=[float, float],
         chunkss=[(2, 2), (2, 2)],
@@ -317,6 +323,7 @@ def test_blockwise_multiple_outputs_fails_different_numblocks(tmp_path):
             allowed_mem=allowed_mem,
             reserved_mem=0,
             target_stores=[target_store1, target_store2],
+            target_names=["target1", "target2"],
             shapes=[(3, 3), (3, 3)],
             dtypes=[float, float],
             chunkss=[(2, 2), (4, 2)],  # numblocks differ

--- a/cubed/tests/primitive/test_blockwise_fusion.py
+++ b/cubed/tests/primitive/test_blockwise_fusion.py
@@ -121,7 +121,7 @@ def make_blockwise_spec(
         num_output_blocks=num_output_blocks,
         iterable_input_blocks=iterable_input_blocks,
         reads_map={},  # unused
-        writes_list=[],  # unused
+        writes_map={},  # unused
     )
 
 


### PR DESCRIPTION
This refactor makes outputs similar to inputs (which are keyed by name) and will help with some future refactors. 