### PR TITLE
Exclude array API test that attempts in-place mutation

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -120,6 +120,7 @@ jobs:
           # not implemented
           array_api_tests/test_array_object.py::test_setitem
           array_api_tests/test_array_object.py::test_setitem_masking
+          array_api_tests/test_creation_functions.py::test_asarray_arrays
           array_api_tests/test_manipulation_functions.py::test_repeat
           array_api_tests/test_sorting_functions.py
 


### PR DESCRIPTION
See #752 (this fixes one of the more common failures).