### PR TITLE
Only run Zarr v2 CI tests on default local executors

### DIFF
--- a/.github/workflows/zarr-v2-tests.yml
+++ b/.github/workflows/zarr-v2-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install -e .[test,lithops]
+          python -m pip install -e .[test]
           python -m pip install -U 'zarr<3'
 
       - name: Run tests


### PR DESCRIPTION
Don't run on Lithops in CI as it is flaky (#758), which might mask any failures due to Zarr v2/v3 differences.