### PR TITLE
Run lithops CI on ubuntu-22.04

### DIFF
--- a/.github/workflows/lithops-tests.yml
+++ b/.github/workflows/lithops-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-22.04", "macos-latest"]
         python-version: ["3.11"]
 
     steps:


### PR DESCRIPTION
Lithops CI has been failing on Linux for a while, and it looks like running on `ubuntu-latest` (currently `ubuntu-24.04`, see https://github.com/actions/runner-images) is the culprit. When rolling back to `ubuntu-22.04` it will sometimes hang, but it will also sometimes pass, whereas `ubuntu-24.04` would only fail or hang.

So I'm going to merge this change, and raise an issue upstream in Lithops.