### PR TITLE
Ensure chunks are square for `eye`

### DIFF
--- a/cubed/array_api/creation_functions.py
+++ b/cubed/array_api/creation_functions.py
@@ -116,7 +116,11 @@ def eye(
 
     shape = (n_rows, n_cols)
     chunks = normalize_chunks(chunks, shape=shape, dtype=dtype)
-    chunksize = to_chunksize(chunks)[0]
+    vchunksize, hchunksize = to_chunksize(chunks)
+
+    # chunksize must be same for rows and cols for current implementation
+    chunksize = min(vchunksize, hchunksize)
+    chunks = normalize_chunks((chunksize, chunksize), shape=shape, dtype=dtype)
 
     return map_blocks(
         _eye,

--- a/cubed/tests/test_array_api.py
+++ b/cubed/tests/test_array_api.py
@@ -111,6 +111,11 @@ def test_eye(spec, k):
     assert_array_equal(a, np.eye(5, k=k))
 
 
+def test_eye_not_square():
+    a = xp.eye(1, 3, k=2)
+    assert_array_equal(a, np.eye(1, 3, k=2))
+
+
 @pytest.mark.parametrize("endpoint", [True, False])
 def test_linspace(spec, endpoint):
     a = xp.linspace(6, 49, 50, endpoint=endpoint, chunks=5, spec=spec)


### PR DESCRIPTION
Part of #752

This bug was found in https://github.com/cubed-dev/cubed/actions/runs/16411405424/job/46367054535 

```
Falsifying example: test_eye(
    |     n_rows=1,
    |     n_cols=3,
    |     kw={'k': 2},
    | )
```