### PR TITLE
Run lithops tests CI on both ubuntu-22.04 and ubuntu-24.04

### DIFF
--- a/.github/workflows/lithops-tests.yml
+++ b/.github/workflows/lithops-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "macos-latest"]
+        os: ["ubuntu-22.04", "ubuntu-24.04", "macos-latest"]
         python-version: ["3.11"]
 
     steps:


### PR DESCRIPTION
Newly released Lithops 3.6.1 has a new fix for #753 (details in https://github.com/lithops-cloud/lithops/issues/1438). This PR reinstates running on ubuntu-24.04.