### PR TITLE
Make `itemsize` support other Array API implementations

### DIFF
--- a/cubed/backend_array_api.py
+++ b/cubed/backend_array_api.py
@@ -59,5 +59,17 @@ def numpy_array_to_backend_array(arr, *, dtype=None):
     return namespace.asarray(arr, dtype=dtype)
 
 
+def backend_dtype_to_numpy_dtype(dtype):
+    if isinstance(dtype, np.dtype):
+        return dtype
+    elif isinstance(dtype, list):
+        return np.dtype(
+            [(field[0], backend_dtype_to_numpy_dtype(field[1])) for field in dtype]
+        )
+    else:
+        a = namespace.empty((), dtype=dtype)
+        return np.dtype(backend_array_to_numpy_array(a).dtype)
+
+
 # jax doesn't support in-place assignment, so we use .at[].set() instead.
 IS_IMMUTABLE_ARRAY = "jax" in xp_name

--- a/cubed/tests/test_utils.py
+++ b/cubed/tests/test_utils.py
@@ -14,6 +14,7 @@ from cubed.utils import (
     extract_stack_summaries,
     is_cloud_storage_path,
     is_local_path,
+    itemsize,
     join_path,
     map_nested,
     memory_repr,
@@ -30,6 +31,15 @@ def test_array_memory():
     assert array_memory(np.int32, (3,)) == 12
     assert array_memory(np.int32, (3, 5)) == 60
     assert array_memory(np.int32, (0,)) == 0
+
+
+def test_itemsize():
+    assert itemsize(np.bool) == 1
+    assert itemsize(np.int32) == 4
+    assert itemsize(np.int64) == 8
+    assert itemsize(np.dtype(np.int64)) == 8
+    assert itemsize([("a", np.int32), ("b", np.int64)]) == 12
+    assert itemsize(np.dtype([("a", np.int32), ("b", np.int64)])) == 12
 
 
 def test_block_id_to_offset():


### PR DESCRIPTION
Part of #770 