### PR TITLE
Explicitly use Beam Direct Runner in tests since default is now Prism

### DIFF
--- a/cubed/runtime/executors/beam.py
+++ b/cubed/runtime/executors/beam.py
@@ -82,13 +82,18 @@ class _SingleArgumentStage(beam.PTransform):
 class BeamExecutor(DagExecutor):
     """An execution engine that uses Apache Beam."""
 
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
     @property
     def name(self) -> str:
         return "beam"
 
     def execute_dag(self, dag, callbacks=None, spec=None, compute_id=None, **kwargs):
+        merged_kwargs = {**self.kwargs, **kwargs}
+
         dag = dag.copy()
-        pipeline = beam.Pipeline(**kwargs)
+        pipeline = beam.Pipeline(**merged_kwargs)
 
         for name, node in visit_nodes(dag):
             cubed_pipeline = node["pipeline"]

--- a/cubed/tests/utils.py
+++ b/cubed/tests/utils.py
@@ -35,8 +35,12 @@ if platform.system() != "Windows":
     MAIN_EXECUTORS.append(create_executor("processes"))
 
 try:
-    ALL_EXECUTORS.append(create_executor("beam"))
-    MAIN_EXECUTORS.append(create_executor("beam"))
+    ALL_EXECUTORS.append(
+        create_executor("beam", executor_options=dict(runner="FnApiRunner"))
+    )
+    MAIN_EXECUTORS.append(
+        create_executor("beam", executor_options=dict(runner="FnApiRunner"))
+    )
 except ImportError:
     pass
 


### PR DESCRIPTION
Fixes #812 

The problem was in https://github.com/apache/beam/releases/tag/v2.68.0:

> (Python) Prism runner now enabled by default for most Python pipelines using the direct runner (https://github.com/apache/beam/pull/34612). This may break some tests, see https://github.com/apache/beam/pull/34612 for details on how to handle issues.
