### PR TITLE
Allow int dtypes in mean (and std, var)

### DIFF
--- a/cubed/tests/test_array_api.py
+++ b/cubed/tests/test_array_api.py
@@ -910,6 +910,12 @@ def test_mean_complex():
     assert_array_equal(b.compute(), np.array([1.0+1.0j, 2.0+2.0j, 3.0+3.0j]).mean())
 
 
+def test_mean_int():
+    a = xp.asarray([1, 2, 3], chunks=(2,))
+    b = xp.mean(a)
+    assert_array_equal(b.compute(), np.array([1, 2, 3]).mean())
+
+
 def test_sum(spec, executor):
     a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
     b = xp.sum(a)
@@ -938,6 +944,12 @@ def test_var(spec, axis, correction, keepdims):
             axis=axis, ddof=correction, keepdims=keepdims
         ),
     )
+
+
+def test_var_int():
+    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2))
+    b = xp.var(a)
+    assert_array_equal(b.compute(), np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).var())
 
 
 @pytest.mark.parametrize("axis", [None, 0, 1, (0, 1)])


### PR DESCRIPTION
Loosen from just floating dtypes, as ints are often passed to mean in practice.

From https://data-apis.org/array-api/latest/API_specification/generated/array_api.mean.html#array_api.mean:

> While this specification recommends that this function only accept input arrays having a floating-point data type, specification-compliant array libraries may choose to accept input arrays having an integer data type. While mixed data type promotion is implementation-defined, if the input array x has an integer data type, the returned array must have the default real-valued floating-point data type.