### PR TITLE
Improve detection of array names in `visualize`

### DIFF
--- a/cubed/array_api/creation_functions.py
+++ b/cubed/array_api/creation_functions.py
@@ -72,7 +72,8 @@ def asarray(
     name = gensym()
     target = virtual_in_memory(a, chunks=chunksize)
 
-    plan = Plan._new(name, "asarray", target)
+    scalar_value = str(a) if a.shape == () else None
+    plan = Plan._new(name, "asarray", target, scalar_value=scalar_value)
     return Array(name, target, spec, plan)
 
 

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -395,6 +395,7 @@ def blockwise(
         op.target_array,
         op,
         False,
+        None,
         *source_arrays,
     )
     from cubed.array_api import Array
@@ -555,6 +556,7 @@ def _general_blockwise(
         op.target_array,
         op,
         False,
+        None,
         *source_arrays,
     )
     from cubed.array_api import Array
@@ -975,6 +977,7 @@ def rechunk(x, chunks, *, target_store=None, min_mem=None, use_new_impl=True):
             op.target_array,
             op,
             False,
+            None,
             x,
         )
         return Array(name, op.target_array, spec, plan)
@@ -987,6 +990,7 @@ def rechunk(x, chunks, *, target_store=None, min_mem=None, use_new_impl=True):
             op1.target_array,
             op1,
             False,
+            None,
             x,
         )
         x_int = Array(name_int, op1.target_array, spec, plan1)
@@ -998,6 +1002,7 @@ def rechunk(x, chunks, *, target_store=None, min_mem=None, use_new_impl=True):
             op2.target_array,
             op2,
             False,
+            None,
             x_int,
         )
         return Array(name, op2.target_array, spec, plan2)


### PR DESCRIPTION
* Find arrays in Xarray datasets (see example below)
* Fix bug where cubed_xarray wasn't being considered
* Filter out variable names starting with `_`
* Show literal value of scalar arrays

<img width="764" height="380" alt="Screenshot 2025-11-20 at 13 32 45" src="https://github.com/user-attachments/assets/b5757f6d-b5e6-42b2-8b84-5111829a80c3" />
