### PR TITLE
Pass executor options to default threads executor

### DIFF
--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -6,6 +6,7 @@ from toolz import map, reduce
 from cubed import config
 from cubed.backend_array_api import namespace as nxp
 from cubed.backend_array_api import numpy_array_to_backend_array
+from cubed.runtime.create import create_executor
 from cubed.runtime.types import Callback, Executor
 from cubed.spec import Spec, spec_from_config
 from cubed.storage.zarr import open_if_lazy_zarr_array
@@ -296,11 +297,9 @@ def compute(
         compile_function=compile_function,
     )
     if executor is None:
-        executor = arrays[0].spec.executor
+        executor = spec.executor
         if executor is None:
-            from cubed.runtime.executors.local import ThreadsExecutor
-
-            executor = ThreadsExecutor()
+            executor = create_executor("threads", spec.executor_options)
 
     # combine any callbacks specified as args with any active callbacks from the context manager
     if callbacks is None and len(Callback.active) == 0:

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import random
 from functools import partial
@@ -504,7 +505,11 @@ def test_default_spec_config_override():
     from cubed import config
 
     with config.set(
-        {"spec.allowed_mem": "4GB", "spec.executor_name": "single-threaded"}
+        {
+            "spec.allowed_mem": "4GB",
+            # need to decrease max workers proportionately
+            "spec.executor_options.max_workers": os.cpu_count() // 2,
+        }
     ):
         a = xp.ones((20000, 10000), chunks=(10000, 10000))
         b = xp.negative(a)


### PR DESCRIPTION
This fixes a bug where the executor options are not picked up for the default threads executor. (Without the main change the test fails because `max_workers` isn't picked up.)