### PR TITLE
Fix to allow cubed to work without diagnostics

### DIFF
--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -13,7 +13,6 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 import networkx as nx
 
 from cubed.core.optimization import is_input_array, multiple_inputs_optimize_dag
-from cubed.diagnostics.colors import APRICOT, LAVENDER, RED
 from cubed.primitive.blockwise import BlockwiseSpec
 from cubed.primitive.types import PrimitiveOperation
 from cubed.runtime.pipeline import visit_node_generations
@@ -612,6 +611,8 @@ class FinalizedPlan:
         show_hidden=False,
         engine: Literal["cytoscape", "graphviz"] | None = None,
     ):
+        from cubed.diagnostics.colors import APRICOT, LAVENDER, RED
+
         if engine == "cytoscape":
             return self.visualize_cytoscape(
                 filename,


### PR DESCRIPTION
Fix for the following bug:

```
% pip install 'git+https://github.com/cubed-dev/cubed.git' 
% python
>>> import cubed
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tom/workspace/cubed/cubed/__init__.py", line 16, in <module>
    import cubed.random  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^
  File "/Users/tom/workspace/cubed/cubed/random.py", line 7, in <module>
    from cubed.core.ops import map_blocks
  File "/Users/tom/workspace/cubed/cubed/core/__init__.py", line 2, in <module>
    from .array import CoreArray, compute, gensym, measure_reserved_mem, visualize
  File "/Users/tom/workspace/cubed/cubed/core/array.py", line 15, in <module>
    from .plan import FinalizedPlan, arrays_to_plan
  File "/Users/tom/workspace/cubed/cubed/core/plan.py", line 16, in <module>
    from cubed.diagnostics.colors import APRICOT, LAVENDER, RED
  File "/Users/tom/workspace/cubed/cubed/diagnostics/__init__.py", line 1, in <module>
    from .rich import RichProgressBar as ProgressBar
  File "/Users/tom/workspace/cubed/cubed/diagnostics/rich.py", line 6, in <module>
    from rich.console import RenderableType
ModuleNotFoundError: No module named 'rich'
```
