### PR TITLE
Fix lazy open bug

### DIFF
--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -240,7 +240,7 @@ def extract_array_names(frame: FrameType) -> dict[str, str]:
         ):
             # Note: We use ._data here instead of .data to avoid eager loading inside xarray.open_dataset internals - see https://github.com/cubed-dev/cubed/issues/855
             if isinstance(obj.variable._data, Array):
-                array_names_to_variable_names[obj._data.name] = name
+                array_names_to_variable_names[obj.variable._data.name] = name
         elif (
             type(obj).__module__.split(".")[0] == "xarray"
             and obj.__class__.__name__ == "Dataset"


### PR DESCRIPTION
Fixes https://github.com/cubed-dev/cubed/issues/855 by using `._data` as suggested.

However I get another weird error with the diagnostics code:

<details>

```python
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
File [/opt/coiled/env/lib/python3.12/site-packages/IPython/core/formatters.py:406](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/IPython/core/formatters.py#line=405), in BaseFormatter.__call__(self, obj)
    404     method = get_real_method(obj, self.print_method)
    405     if method is not None:
--> 406         return method()
    407     return None
    408 else:

File [/opt/coiled/env/lib/python3.12/site-packages/xarray/core/dataset.py:2404](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/xarray/core/dataset.py#line=2403), in Dataset._repr_html_(self)
   2402 if OPTIONS["display_style"] == "text":
   2403     return f"<pre>{escape(repr(self))}<[/pre](https://cluster-nhecq.dask.host/pre)>"
-> 2404 return formatting_html.dataset_repr(self)

File [/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py:374](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py#line=373), in dataset_repr(ds)
    371 if ds.coords:
    372     sections.append(coord_section(ds.coords))
--> 374 sections.append(datavar_section(ds.data_vars))
    376 display_default_indexes = _get_boolean_with_default(
    377     "display_default_indexes", False
    378 )
    379 xindexes = filter_nondefault_indexes(
    380     _get_indexes_dict(ds.xindexes), not display_default_indexes
    381 )

File [/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py:224](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py#line=223), in _mapping_section(mapping, name, details_func, max_items_collapse, expand_option_name, enabled, max_option_name)
    218     if n_items > max_items:
    219         inline_details = f"({max_items}[/](https://cluster-nhecq.dask.host/){n_items})"
    221 return collapsible_section(
    222     name,
    223     inline_details=inline_details,
--> 224     details=details_func(mapping),
    225     n_items=n_items,
    226     enabled=enabled,
    227     collapsed=collapsed,
    228 )

File [/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py:134](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py#line=133), in summarize_vars(variables)
    133 def summarize_vars(variables) -> str:
--> 134     vars_li = "".join(
    135         f"<li class='xr-var-item'>{summarize_variable(k, v)}<[/li](https://cluster-nhecq.dask.host/li)>"
    136         for k, v in variables.items()
    137     )
    139     return f"<ul class='xr-var-list'>{vars_li}<[/ul](https://cluster-nhecq.dask.host/ul)>"

File [/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py:135](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py#line=134), in <genexpr>(.0)
    133 def summarize_vars(variables) -> str:
    134     vars_li = "".join(
--> 135         f"<li class='xr-var-item'>{summarize_variable(k, v)}<[/li](https://cluster-nhecq.dask.host/li)>"
    136         for k, v in variables.items()
    137     )
    139     return f"<ul class='xr-var-list'>{vars_li}<[/ul](https://cluster-nhecq.dask.host/ul)>"

File [/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py:96](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py#line=95), in summarize_variable(name, var, is_index, dtype)
     94 preview = escape(inline_variable_array_repr(variable, 35))
     95 attrs_ul = summarize_attrs(var.attrs)
---> 96 data_repr = short_data_repr_html(variable)
     98 attrs_icon = _icon("icon-file-text2")
     99 data_icon = _icon("icon-database")

File [/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py:43](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/xarray/core/formatting_html.py#line=42), in short_data_repr_html(array)
     41 internal_data = getattr(array, "variable", array)._data
     42 if hasattr(internal_data, "_repr_html_"):
---> 43     return internal_data._repr_html_()
     44 text = escape(short_data_repr(array))
     45 return f"<pre>{text}<[/pre](https://cluster-nhecq.dask.host/pre)>"

File [/opt/coiled/env/lib/python3.12/site-packages/cubed/array_api/array_object.py:50](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/cubed/array_api/array_object.py#line=49), in Array._repr_html_(self)
     49 def _repr_html_(self):
---> 50     from cubed.diagnostics.widgets import get_template
     52     try:
     53         grid = self.to_svg(size=ARRAY_SVG_SIZE)

File [/opt/coiled/env/lib/python3.12/site-packages/cubed/diagnostics/widgets/__init__.py:9](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/cubed/diagnostics/widgets/__init__.py#line=8)
      1 try:
      2     from cubed.diagnostics.widgets.core import (
      3         FILTERS,
      4         TEMPLATE_PATHS,
      5         get_environment,
      6         get_template,
      7     )
----> 9     from .memory import LiveMemoryViewer, MemoryWidget
     10     from .plan import LivePlanViewer, PlanWidget
     11     from .timeline import LiveTimelineViewer, TimelineWidget

File [/opt/coiled/env/lib/python3.12/site-packages/cubed/diagnostics/widgets/memory.py:13](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/cubed/diagnostics/widgets/memory.py#line=12)
      9 from cubed.runtime.pipeline import visit_nodes
     10 from cubed.runtime.types import Callback
---> 13 class MemoryWidget(anywidget.AnyWidget):
     14     _esm = pathlib.Path(__file__).parent [/](https://cluster-nhecq.dask.host/) "static" [/](https://cluster-nhecq.dask.host/) "memory_widget.js"
     16     width = traitlets.Unicode("100%").tag(sync=True)

File [/opt/coiled/env/lib/python3.12/site-packages/traitlets/traitlets.py:963](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/traitlets/traitlets.py#line=962), in MetaHasDescriptors.__new__(mcls, name, bases, classdict, **kwds)
    960         classdict[k] = v()
    961     # ----------------------------------------------------------------
--> 963 return super().__new__(mcls, name, bases, classdict, **kwds)

File [/opt/coiled/env/lib/python3.12/site-packages/anywidget/widget.py:71](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/anywidget/widget.py#line=70), in AnyWidget.__init_subclass__(cls, **kwargs)
     67 super().__init_subclass__(**kwargs)
     68 for key in (_ESM_KEY, _CSS_KEY) & cls.__dict__.keys():
     69     # TODO(manzt): Upgrade to := when we drop Python 3.7
     70     # https://github.com/manzt/anywidget/pull/167
---> 71     file_contents = try_file_contents(getattr(cls, key))
     72     if file_contents:
     73         setattr(cls, key, file_contents)

File [/opt/coiled/env/lib/python3.12/site-packages/anywidget/_util.py:280](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/anywidget/_util.py#line=279), in try_file_contents(x)
    278 if not path.is_file():
    279     msg = f"File not found: {path}"
--> 280     raise FileNotFoundError(msg)
    281 return FileContents(
    282     path=path,
    283     start_thread=_should_start_thread(path),
    284 )

FileNotFoundError: File not found: [/opt/coiled/env/lib/python3.12/site-packages/cubed/diagnostics/widgets/static/memory_widget.js](https://cluster-nhecq.dask.host/opt/coiled/env/lib/python3.12/site-packages/cubed/diagnostics/widgets/static/memory_widget.js)
```

</details>

(I'm running this on Azure via a Coiled notebook)

Also doesn't have a test yet.