### PR TITLE
Blockwise fusion improvements

### DIFF
--- a/cubed/array/overlap.py
+++ b/cubed/array/overlap.py
@@ -62,7 +62,7 @@ def map_overlap(
     x = args[0]  # TODO: support multiple input arrays
 
     def selection_function(out_key):
-        out_coords = out_key[1:]
+        out_coords = out_key.coords
         block_id = out_coords
         return get_item_with_depth(x.chunks, block_id, depth[0])
 

--- a/cubed/array_api/linalg.py
+++ b/cubed/array_api/linalg.py
@@ -13,6 +13,7 @@ from cubed.array_api.linear_algebra_functions import (  # noqa: F401
 )
 from cubed.backend_array_api import namespace as nxp
 from cubed.core.ops import blockwise, general_blockwise, merge_chunks, squeeze
+from cubed.primitive.blockwise import ChunkKey, ChunkKeyCollection
 from cubed.utils import array_memory, get_item
 
 
@@ -189,9 +190,9 @@ def _qr_third_step(Q1, Q2):
     # These aren't the actual chunks, but the chunks we need for _q_matmul
     Q2_chunks = ((n,) * k, (n,))
 
-    def key_function(out_key):
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
         # Q1 is a simple 1:1 mapping, Q2_single has a single chunk
-        return ((Q1.name,) + out_key[1:], (Q2_single.name,) + (0, 0))
+        return (ChunkKey(Q1.name, out_key.coords), ChunkKey(Q2_single.name, (0, 0)))
 
     Q = general_blockwise(
         _q_matmul,
@@ -245,8 +246,8 @@ def map_blocks_multiple_outputs(
     chunkss,
     **kwargs,
 ):
-    def key_function(out_key):
-        return tuple((array.name,) + out_key[1:] for array in args)
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        return tuple(ChunkKey(array.name, out_key.coords) for array in args)
 
     return general_blockwise(
         func,

--- a/cubed/array_api/linalg.py
+++ b/cubed/array_api/linalg.py
@@ -13,7 +13,7 @@ from cubed.array_api.linear_algebra_functions import (  # noqa: F401
 )
 from cubed.backend_array_api import namespace as nxp
 from cubed.core.ops import blockwise, general_blockwise, merge_chunks, squeeze
-from cubed.primitive.blockwise import ChunkKey, FunctionArgs, KeyFunctionResult
+from cubed.primitive.blockwise import ChunkKey, FunctionArgs
 from cubed.utils import array_memory, get_item
 
 
@@ -190,7 +190,7 @@ def _qr_third_step(Q1, Q2):
     # These aren't the actual chunks, but the chunks we need for _q_matmul
     Q2_chunks = ((n,) * k, (n,))
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         # Q1 is a simple 1:1 mapping, Q2_single has a single chunk
         return FunctionArgs(
             ChunkKey(Q1.name, out_key.coords),
@@ -250,7 +250,7 @@ def map_blocks_multiple_outputs(
     chunkss,
     **kwargs,
 ):
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         return FunctionArgs(
             *tuple(ChunkKey(array.name, out_key.coords) for array in args),
             output_name=out_key.name,

--- a/cubed/array_api/linalg.py
+++ b/cubed/array_api/linalg.py
@@ -13,7 +13,7 @@ from cubed.array_api.linear_algebra_functions import (  # noqa: F401
 )
 from cubed.backend_array_api import namespace as nxp
 from cubed.core.ops import blockwise, general_blockwise, merge_chunks, squeeze
-from cubed.primitive.blockwise import ChunkKey, ChunkKeyCollection
+from cubed.primitive.blockwise import ChunkKey, FunctionArgs, KeyFunctionResult
 from cubed.utils import array_memory, get_item
 
 
@@ -190,9 +190,13 @@ def _qr_third_step(Q1, Q2):
     # These aren't the actual chunks, but the chunks we need for _q_matmul
     Q2_chunks = ((n,) * k, (n,))
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         # Q1 is a simple 1:1 mapping, Q2_single has a single chunk
-        return (ChunkKey(Q1.name, out_key.coords), ChunkKey(Q2_single.name, (0, 0)))
+        return FunctionArgs(
+            ChunkKey(Q1.name, out_key.coords),
+            ChunkKey(Q2_single.name, (0, 0)),
+            output_name=out_key.name,
+        )
 
     Q = general_blockwise(
         _q_matmul,
@@ -246,8 +250,11 @@ def map_blocks_multiple_outputs(
     chunkss,
     **kwargs,
 ):
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
-        return tuple(ChunkKey(array.name, out_key.coords) for array in args)
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+        return FunctionArgs(
+            *tuple(ChunkKey(array.name, out_key.coords) for array in args),
+            output_name=out_key.name,
+        )
 
     return general_blockwise(
         func,

--- a/cubed/array_api/linalg.py
+++ b/cubed/array_api/linalg.py
@@ -190,7 +190,7 @@ def _qr_third_step(Q1, Q2):
     # These aren't the actual chunks, but the chunks we need for _q_matmul
     Q2_chunks = ((n,) * k, (n,))
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         # Q1 is a simple 1:1 mapping, Q2_single has a single chunk
         return FunctionArgs(
             ChunkKey(Q1.name, out_key.coords),
@@ -200,7 +200,7 @@ def _qr_third_step(Q1, Q2):
 
     Q = general_blockwise(
         _q_matmul,
-        key_function,
+        back_key_function,
         Q1,
         Q2_single,
         shapes=[Q1_shape],
@@ -250,7 +250,7 @@ def map_blocks_multiple_outputs(
     chunkss,
     **kwargs,
 ):
-    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         return FunctionArgs(
             *tuple(ChunkKey(array.name, out_key.coords) for array in args),
             output_name=out_key.name,
@@ -258,7 +258,7 @@ def map_blocks_multiple_outputs(
 
     return general_blockwise(
         func,
-        key_function,
+        back_key_function,
         *args,
         shapes=shapes,
         dtypes=dtypes,

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -20,7 +20,7 @@ from cubed.core.ops import (
     map_blocks,
     map_selection,
 )
-from cubed.primitive.blockwise import ChunkKey, ChunkKeyCollection
+from cubed.primitive.blockwise import ChunkKey, FunctionArgs, KeyFunctionResult
 from cubed.utils import (
     block_id_to_offset,
     get_item,
@@ -152,7 +152,7 @@ def concat(arrays, /, *, axis=0, chunks=None):
     else:
         chunks = normalize_chunks(chunks, shape=shape, dtype=dtype)
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         out_coords = out_key.coords
         block_id = out_coords
 
@@ -177,7 +177,9 @@ def concat(arrays, /, *, axis=0, chunks=None):
 
             in_keys.extend([ChunkKey(a.name, cp.chunk_coords) for cp in indexer])
 
-        return (iter(tuple(in_key for in_key in in_keys)),)
+        return FunctionArgs(
+            iter(tuple(in_key for in_key in in_keys)), output_name=out_key.name
+        )
 
     num_input_blocks = (1,) * len(arrays)
     iterable_input_blocks = (True,) * len(arrays)
@@ -413,12 +415,12 @@ def repeat(x, repeats, /, *, axis=0):
     # This implementation calls nxp.repeat in every output block, which is 'repeats' times
     # more than necessary than if we had a primitive op that could write multiple blocks.
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         out_coords = out_key.coords
         in_coords = tuple(
             bi // repeats if i == axis else bi for i, bi in enumerate(out_coords)
         )
-        return (ChunkKey(x.name, in_coords),)
+        return FunctionArgs(ChunkKey(x.name, in_coords), output_name=out_key.name)
 
     # extra memory from calling 'nxp.repeat' on a chunk
     extra_projected_mem = x.chunkmem * repeats
@@ -489,13 +491,14 @@ def reshape_chunks(x, shape, chunks):
     # use an empty template (handles smaller end chunks)
     template = empty(shape, dtype=x.dtype, chunks=chunks, spec=x.spec)
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         out_coords = out_key.coords
         offset = block_id_to_offset(out_coords, template.numblocks)
         in_coords = offset_to_block_id(offset, x.numblocks)
-        return (
+        return FunctionArgs(
             ChunkKey(x.name, in_coords),
             ChunkKey(template.name, out_coords),
+            output_name=out_key.name,
         )
 
     return general_blockwise(
@@ -571,10 +574,13 @@ def stack(arrays, /, *, axis=0):
 
     array_names = [a.name for a in arrays]
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         out_coords = out_key.coords
         in_name = array_names[out_coords[axis]]
-        return (ChunkKey(in_name, out_coords[:axis] + out_coords[(axis + 1) :]),)
+        return FunctionArgs(
+            ChunkKey(in_name, out_coords[:axis] + out_coords[(axis + 1) :]),
+            output_name=out_key.name,
+        )
 
     # We have to mark this as fusable_with_predecessors=False since the number of input args to
     # the _read_stack_chunk function is *not* the same as the number of
@@ -626,13 +632,16 @@ def unstack(x, /, *, axis=0):
     dtype = x.dtype
     chunks = x.chunks[:axis] + x.chunks[axis + 1 :]
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         out_coords = out_key.coords
         all_in_coords = tuple(
             out_coords[:axis] + (i,) + out_coords[axis:]
             for i in range(x.numblocks[axis])
         )
-        return tuple(ChunkKey(x.name, in_coords) for in_coords in all_in_coords)
+        return FunctionArgs(
+            *tuple(ChunkKey(x.name, in_coords) for in_coords in all_in_coords),
+            output_name=out_key.name,
+        )
 
     return general_blockwise(
         _unstack_chunk,

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -20,6 +20,7 @@ from cubed.core.ops import (
     map_blocks,
     map_selection,
 )
+from cubed.primitive.blockwise import ChunkKey, ChunkKeyCollection
 from cubed.utils import (
     block_id_to_offset,
     get_item,
@@ -151,8 +152,8 @@ def concat(arrays, /, *, axis=0, chunks=None):
     else:
         chunks = normalize_chunks(chunks, shape=shape, dtype=dtype)
 
-    def key_function(out_key):
-        out_coords = out_key[1:]
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        out_coords = out_key.coords
         block_id = out_coords
 
         # determine the start and stop indexes for this block along the axis dimension
@@ -174,7 +175,7 @@ def concat(arrays, /, *, axis=0, chunks=None):
             a = arrays[ai]
             indexer = _create_zarr_indexer(key, a.shape, a.chunksize)
 
-            in_keys.extend([(a.name,) + cp.chunk_coords for cp in indexer])
+            in_keys.extend([ChunkKey(a.name, cp.chunk_coords) for cp in indexer])
 
         return (iter(tuple(in_key for in_key in in_keys)),)
 
@@ -307,7 +308,7 @@ def flip(x, /, *, axis=None):
     axis = validate_axis(axis, x.ndim)
 
     def selection_function(out_key):
-        out_coords = out_key[1:]
+        out_coords = out_key.coords
         block_id = out_coords
 
         # produce a key that has slices (except for axis dimensions, which are replaced below)
@@ -412,12 +413,12 @@ def repeat(x, repeats, /, *, axis=0):
     # This implementation calls nxp.repeat in every output block, which is 'repeats' times
     # more than necessary than if we had a primitive op that could write multiple blocks.
 
-    def key_function(out_key):
-        out_coords = out_key[1:]
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        out_coords = out_key.coords
         in_coords = tuple(
             bi // repeats if i == axis else bi for i, bi in enumerate(out_coords)
         )
-        return ((x.name, *in_coords),)
+        return (ChunkKey(x.name, in_coords),)
 
     # extra memory from calling 'nxp.repeat' on a chunk
     extra_projected_mem = x.chunkmem * repeats
@@ -488,13 +489,13 @@ def reshape_chunks(x, shape, chunks):
     # use an empty template (handles smaller end chunks)
     template = empty(shape, dtype=x.dtype, chunks=chunks, spec=x.spec)
 
-    def key_function(out_key):
-        out_coords = out_key[1:]
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        out_coords = out_key.coords
         offset = block_id_to_offset(out_coords, template.numblocks)
         in_coords = offset_to_block_id(offset, x.numblocks)
         return (
-            (x.name, *in_coords),
-            (template.name, *out_coords),
+            ChunkKey(x.name, in_coords),
+            ChunkKey(template.name, out_coords),
         )
 
     return general_blockwise(
@@ -570,10 +571,10 @@ def stack(arrays, /, *, axis=0):
 
     array_names = [a.name for a in arrays]
 
-    def key_function(out_key):
-        out_coords = out_key[1:]
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        out_coords = out_key.coords
         in_name = array_names[out_coords[axis]]
-        return ((in_name, *(out_coords[:axis] + out_coords[(axis + 1) :])),)
+        return (ChunkKey(in_name, out_coords[:axis] + out_coords[(axis + 1) :]),)
 
     # We have to mark this as fusable_with_predecessors=False since the number of input args to
     # the _read_stack_chunk function is *not* the same as the number of
@@ -625,13 +626,13 @@ def unstack(x, /, *, axis=0):
     dtype = x.dtype
     chunks = x.chunks[:axis] + x.chunks[axis + 1 :]
 
-    def key_function(out_key):
-        out_coords = out_key[1:]
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        out_coords = out_key.coords
         all_in_coords = tuple(
             out_coords[:axis] + (i,) + out_coords[axis:]
             for i in range(x.numblocks[axis])
         )
-        return tuple((x.name,) + in_coords for in_coords in all_in_coords)
+        return tuple(ChunkKey(x.name, in_coords) for in_coords in all_in_coords)
 
     return general_blockwise(
         _unstack_chunk,

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -153,7 +153,7 @@ def concat(arrays, /, *, axis=0, chunks=None):
     else:
         chunks = normalize_chunks(chunks, shape=shape, dtype=dtype)
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
         out_coords = out_key.coords
         block_id = out_coords
 
@@ -192,7 +192,7 @@ def concat(arrays, /, *, axis=0, chunks=None):
     # This also affects stack.
     return general_blockwise(
         _read_concat_chunk,
-        key_function,
+        back_key_function,
         *arrays,
         shapes=[shape],
         dtypes=[dtype],
@@ -416,7 +416,7 @@ def repeat(x, repeats, /, *, axis=0):
     # This implementation calls nxp.repeat in every output block, which is 'repeats' times
     # more than necessary than if we had a primitive op that could write multiple blocks.
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         in_coords = tuple(
             bi // repeats if i == axis else bi for i, bi in enumerate(out_coords)
@@ -427,7 +427,7 @@ def repeat(x, repeats, /, *, axis=0):
     extra_projected_mem = x.chunkmem * repeats
     return general_blockwise(
         _repeat,
-        key_function,
+        back_key_function,
         x,
         shapes=[shape],
         dtypes=[x.dtype],
@@ -492,7 +492,7 @@ def reshape_chunks(x, shape, chunks):
     # use an empty template (handles smaller end chunks)
     template = empty(shape, dtype=x.dtype, chunks=chunks, spec=x.spec)
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         offset = block_id_to_offset(out_coords, template.numblocks)
         in_coords = offset_to_block_id(offset, x.numblocks)
@@ -504,7 +504,7 @@ def reshape_chunks(x, shape, chunks):
 
     return general_blockwise(
         _reshape_chunk,
-        key_function,
+        back_key_function,
         x,
         template,
         shapes=[shape],
@@ -575,7 +575,7 @@ def stack(arrays, /, *, axis=0):
 
     array_names = [a.name for a in arrays]
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         in_name = array_names[out_coords[axis]]
         return FunctionArgs(
@@ -589,7 +589,7 @@ def stack(arrays, /, *, axis=0):
     # assume they are the same. See https://github.com/cubed-dev/cubed/issues/414
     return general_blockwise(
         _read_stack_chunk,
-        key_function,
+        back_key_function,
         *arrays,
         shapes=[shape],
         dtypes=[dtype],
@@ -633,7 +633,7 @@ def unstack(x, /, *, axis=0):
     dtype = x.dtype
     chunks = x.chunks[:axis] + x.chunks[axis + 1 :]
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         all_in_coords = tuple(
             out_coords[:axis] + (i,) + out_coords[axis:]
@@ -646,7 +646,7 @@ def unstack(x, /, *, axis=0):
 
     return general_blockwise(
         _unstack_chunk,
-        key_function,
+        back_key_function,
         x,
         shapes=[shape] * n_arrays,
         dtypes=[dtype] * n_arrays,

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -183,7 +183,6 @@ def concat(arrays, /, *, axis=0, chunks=None):
         )
 
     num_input_blocks = (1,) * len(arrays)
-    iterable_input_blocks = (True,) * len(arrays)
 
     # We have to mark this as fusable_with_predecessors=False since the number of input args to
     # the _read_concat_chunk function is *not* the same as the number of
@@ -198,7 +197,6 @@ def concat(arrays, /, *, axis=0, chunks=None):
         dtypes=[dtype],
         chunkss=[chunks],
         num_input_blocks=num_input_blocks,
-        iterable_input_blocks=iterable_input_blocks,
         extra_func_kwargs=dict(dtype=dtype),
         target_shape=shape,
         target_chunks=chunks,

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -205,7 +205,7 @@ def concat(arrays, /, *, axis=0, chunks=None):
         offsets=offsets,
         in_shapes=in_shapes,
         function_nargs=1,
-        fusable_with_predecessors=False,
+        # fusable_with_predecessors=False,
     )
 
 
@@ -595,7 +595,7 @@ def stack(arrays, /, *, axis=0):
         chunkss=[chunks],
         axis=axis,
         function_nargs=1,
-        fusable_with_predecessors=False,
+        # fusable_with_predecessors=False,
     )
 
 

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -1,5 +1,6 @@
 from bisect import bisect
 from operator import add, mul
+from typing import Iterator
 
 import tlz
 from toolz import reduce
@@ -20,7 +21,7 @@ from cubed.core.ops import (
     map_blocks,
     map_selection,
 )
-from cubed.primitive.blockwise import ChunkKey, FunctionArgs, KeyFunctionResult
+from cubed.primitive.blockwise import ChunkKey, FunctionArgs
 from cubed.utils import (
     block_id_to_offset,
     get_item,
@@ -152,7 +153,7 @@ def concat(arrays, /, *, axis=0, chunks=None):
     else:
         chunks = normalize_chunks(chunks, shape=shape, dtype=dtype)
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
         out_coords = out_key.coords
         block_id = out_coords
 
@@ -415,7 +416,7 @@ def repeat(x, repeats, /, *, axis=0):
     # This implementation calls nxp.repeat in every output block, which is 'repeats' times
     # more than necessary than if we had a primitive op that could write multiple blocks.
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         in_coords = tuple(
             bi // repeats if i == axis else bi for i, bi in enumerate(out_coords)
@@ -491,7 +492,7 @@ def reshape_chunks(x, shape, chunks):
     # use an empty template (handles smaller end chunks)
     template = empty(shape, dtype=x.dtype, chunks=chunks, spec=x.spec)
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         offset = block_id_to_offset(out_coords, template.numblocks)
         in_coords = offset_to_block_id(offset, x.numblocks)
@@ -574,7 +575,7 @@ def stack(arrays, /, *, axis=0):
 
     array_names = [a.name for a in arrays]
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         in_name = array_names[out_coords[axis]]
         return FunctionArgs(
@@ -632,7 +633,7 @@ def unstack(x, /, *, axis=0):
     dtype = x.dtype
     chunks = x.chunks[:axis] + x.chunks[axis + 1 :]
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         all_in_coords = tuple(
             out_coords[:axis] + (i,) + out_coords[axis:]

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -574,6 +574,9 @@ def stack(arrays, /, *, axis=0):
             output_name=out_key.name,
         )
 
+    # this is too conservative - only one array is read from
+    num_input_blocks = (1,) * len(arrays)
+
     return general_blockwise(
         _read_stack_chunk,
         back_key_function,
@@ -581,6 +584,7 @@ def stack(arrays, /, *, axis=0):
         shapes=[shape],
         dtypes=[dtype],
         chunkss=[chunks],
+        num_input_blocks=num_input_blocks,
         axis=axis,
     )
 

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -205,7 +205,6 @@ def concat(arrays, /, *, axis=0, chunks=None):
         axis=axis,
         offsets=offsets,
         in_shapes=in_shapes,
-        function_nargs=1,
         # fusable_with_predecessors=False,
     )
 
@@ -595,7 +594,6 @@ def stack(arrays, /, *, axis=0):
         dtypes=[dtype],
         chunkss=[chunks],
         axis=axis,
-        function_nargs=1,
         # fusable_with_predecessors=False,
     )
 

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -184,11 +184,6 @@ def concat(arrays, /, *, axis=0, chunks=None):
 
     num_input_blocks = (1,) * len(arrays)
 
-    # We have to mark this as fusable_with_predecessors=False since the number of input args to
-    # the _read_concat_chunk function is *not* the same as the number of
-    # predecessor nodes in the DAG, and the fusion functions in blockwise
-    # assume they are the same. See https://github.com/cubed-dev/cubed/issues/414
-    # This also affects stack.
     return general_blockwise(
         _read_concat_chunk,
         back_key_function,
@@ -203,7 +198,6 @@ def concat(arrays, /, *, axis=0, chunks=None):
         axis=axis,
         offsets=offsets,
         in_shapes=in_shapes,
-        # fusable_with_predecessors=False,
     )
 
 
@@ -580,10 +574,6 @@ def stack(arrays, /, *, axis=0):
             output_name=out_key.name,
         )
 
-    # We have to mark this as fusable_with_predecessors=False since the number of input args to
-    # the _read_stack_chunk function is *not* the same as the number of
-    # predecessor nodes in the DAG, and the fusion functions in blockwise
-    # assume they are the same. See https://github.com/cubed-dev/cubed/issues/414
     return general_blockwise(
         _read_stack_chunk,
         back_key_function,
@@ -592,7 +582,6 @@ def stack(arrays, /, *, axis=0):
         dtypes=[dtype],
         chunkss=[chunks],
         axis=axis,
-        # fusable_with_predecessors=False,
     )
 
 

--- a/cubed/core/groupby.py
+++ b/cubed/core/groupby.py
@@ -179,7 +179,7 @@ def groupby_blockwise(
     target_chunks = normalize_chunks(chunks, shape, dtype=dtype)
 
     def selection_function(out_key):
-        out_coords = out_key[1:]
+        out_coords = out_key.coords
         block_id = out_coords
         return get_item(read_chunks, block_id)
 

--- a/cubed/core/indexing.py
+++ b/cubed/core/indexing.py
@@ -9,7 +9,7 @@ from toolz import accumulate, map
 from cubed.backend_array_api import backend_array_to_numpy_array
 from cubed.core.array import CoreArray
 from cubed.core.ops import general_blockwise, map_selection, merge_chunks
-from cubed.primitive.blockwise import ChunkKey, ChunkKeyCollection
+from cubed.primitive.blockwise import ChunkKey, FunctionArgs, KeyFunctionResult
 from cubed.utils import array_size, normalize_chunks
 
 if TYPE_CHECKING:
@@ -251,12 +251,14 @@ class BlockView:
                     "Only integer, slice, or int array indexes are supported."
                 )
 
-        def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        def key_function(out_key: ChunkKey) -> KeyFunctionResult:
             out_coords = out_key.coords
             in_coords = tuple(
                 get_dim_index(ia, bi) for ia, bi in zip(idx.args, out_coords)
             )
-            return (ChunkKey(self.array.name, in_coords),)
+            return FunctionArgs(
+                ChunkKey(self.array.name, in_coords), output_name=out_key.name
+            )
 
         out = general_blockwise(
             identity,

--- a/cubed/core/indexing.py
+++ b/cubed/core/indexing.py
@@ -9,7 +9,7 @@ from toolz import accumulate, map
 from cubed.backend_array_api import backend_array_to_numpy_array
 from cubed.core.array import CoreArray
 from cubed.core.ops import general_blockwise, map_selection, merge_chunks
-from cubed.primitive.blockwise import ChunkKey, FunctionArgs, KeyFunctionResult
+from cubed.primitive.blockwise import ChunkKey, FunctionArgs
 from cubed.utils import array_size, normalize_chunks
 
 if TYPE_CHECKING:
@@ -251,7 +251,7 @@ class BlockView:
                     "Only integer, slice, or int array indexes are supported."
                 )
 
-        def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+        def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
             out_coords = out_key.coords
             in_coords = tuple(
                 get_dim_index(ia, bi) for ia, bi in zip(idx.args, out_coords)

--- a/cubed/core/indexing.py
+++ b/cubed/core/indexing.py
@@ -251,7 +251,7 @@ class BlockView:
                     "Only integer, slice, or int array indexes are supported."
                 )
 
-        def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+        def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
             out_coords = out_key.coords
             in_coords = tuple(
                 get_dim_index(ia, bi) for ia, bi in zip(idx.args, out_coords)
@@ -262,7 +262,7 @@ class BlockView:
 
         out = general_blockwise(
             identity,
-            key_function,
+            back_key_function,
             self.array,
             shapes=[shape],
             dtypes=[self.array.dtype],

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -408,7 +408,6 @@ def blockwise(
     fusable_with_predecessors = kwargs.pop("fusable_with_predecessors", True)
     fusable_with_successors = kwargs.pop("fusable_with_successors", True)
     num_input_blocks = kwargs.pop("num_input_blocks", None)
-    iterable_input_blocks = kwargs.pop("iterable_input_blocks", None)
 
     name = gensym()
     spec = check_array_specs(arrays)
@@ -437,7 +436,6 @@ def blockwise(
         fusable_with_predecessors=fusable_with_predecessors,
         fusable_with_successors=fusable_with_successors,
         num_input_blocks=num_input_blocks,
-        iterable_input_blocks=iterable_input_blocks,
         **kwargs,
     )
     plan = Plan._new(
@@ -499,11 +497,6 @@ def general_blockwise(
         num_input_blocks = kwargs.pop("num_input_blocks", None)
         if num_input_blocks is not None:
             num_input_blocks = num_input_blocks + (1,)  # for offsets array
-        iterable_input_blocks = kwargs.pop("iterable_input_blocks", None)
-        if iterable_input_blocks is not None:
-            iterable_input_blocks = iterable_input_blocks + (
-                False,
-            )  # for offsets array
 
         return _general_blockwise(
             func_with_block_id(func),
@@ -516,7 +509,6 @@ def general_blockwise(
             target_paths=target_paths,
             extra_func_kwargs=extra_func_kwargs,
             num_input_blocks=num_input_blocks,
-            iterable_input_blocks=iterable_input_blocks,
             **kwargs,
         )
 
@@ -558,7 +550,6 @@ def _general_blockwise(
     extra_projected_mem = kwargs.pop("extra_projected_mem", 0)
 
     num_input_blocks = kwargs.pop("num_input_blocks", None)
-    iterable_input_blocks = kwargs.pop("iterable_input_blocks", None)
 
     op_name = kwargs.pop("op_name", "blockwise")
 
@@ -597,7 +588,6 @@ def _general_blockwise(
         in_names=in_names,
         extra_func_kwargs=extra_func_kwargs,
         num_input_blocks=num_input_blocks,
-        iterable_input_blocks=iterable_input_blocks,
         **kwargs,
     )
     plan = Plan._new(
@@ -743,7 +733,6 @@ def map_selection(
         )
 
     num_input_blocks = (max_num_input_blocks,)
-    iterable_input_blocks = (True,)
 
     out = general_blockwise(
         _assemble_index_chunk,
@@ -754,7 +743,6 @@ def map_selection(
         chunkss=[chunks],
         extra_func_kwargs=dict(func=func, dtype=x.dtype),
         num_input_blocks=num_input_blocks,
-        iterable_input_blocks=iterable_input_blocks,
         selection_function=selection_function,
         in_shape=x.shape,
         in_chunksize=x.chunksize,
@@ -1336,7 +1324,6 @@ def partial_reduce(
         chunkss=[chunks],
         extra_projected_mem=extra_projected_mem,
         num_input_blocks=(sum(split_every.values()),),
-        iterable_input_blocks=(True,),
         reduce_func=func,
         initial_func=initial_func,
         axis=axis,

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -496,9 +496,6 @@ def general_blockwise(
 
             return wrap
 
-        function_nargs = kwargs.pop("function_nargs", None)
-        if function_nargs is not None:
-            function_nargs = function_nargs + 1  # for offsets array
         num_input_blocks = kwargs.pop("num_input_blocks", None)
         if num_input_blocks is not None:
             num_input_blocks = num_input_blocks + (1,)  # for offsets array
@@ -518,7 +515,6 @@ def general_blockwise(
             target_stores=target_stores,
             target_paths=target_paths,
             extra_func_kwargs=extra_func_kwargs,
-            function_nargs=function_nargs,
             num_input_blocks=num_input_blocks,
             iterable_input_blocks=iterable_input_blocks,
             **kwargs,

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -20,6 +20,7 @@ from cubed.core.array import CoreArray, check_array_specs, gensym
 from cubed.core.array import compute as compute_arrays
 from cubed.core.plan import Plan, intermediate_store
 from cubed.core.rechunk import multistage_regular_rechunking_plan
+from cubed.primitive.blockwise import ChunkKey, ChunkKeyCollection
 from cubed.primitive.blockwise import blockwise as primitive_blockwise
 from cubed.primitive.blockwise import general_blockwise as primitive_general_blockwise
 from cubed.primitive.memory import get_buffer_copies
@@ -233,10 +234,10 @@ def _store_array(
             for sl, cs in zip(region, chunks)
         ]
 
-        def key_function(out_key):
-            out_coords = out_key[1:]
+        def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+            out_coords = out_key.coords
             in_coords = tuple(bi - off for bi, off in zip(out_coords, block_offsets))
-            return ((source.name, *in_coords),)
+            return (ChunkKey(source.name, in_coords),)
 
         # calculate output block ids from region selection
         indexer = _create_zarr_indexer(region, shape, chunks)
@@ -466,8 +467,8 @@ def general_blockwise(
 
         def key_function_with_offset(key_function):
             def wrap(out_key):
-                out_coords = out_key[1:]
-                offset_in_key = ((offsets.name,) + out_coords,)
+                out_coords = out_key.coords
+                offset_in_key = (ChunkKey(offsets.name, out_coords),)
                 return key_function(out_key) + offset_in_key
 
             return wrap
@@ -660,7 +661,7 @@ def _assemble_index_chunk(
 
     # compute the selection on x required to get the relevant chunk for out_coords
     out_coords = block_id
-    in_sel = selection_function(("out",) + out_coords)
+    in_sel = selection_function(ChunkKey("out", out_coords))
 
     # use a Zarr indexer to convert this to input coordinates
     indexer = _create_zarr_indexer(in_sel, in_shape, in_chunksize)
@@ -718,14 +719,14 @@ def map_selection(
         The maximum number of input blocks read from the input array.
     """
 
-    def key_function(out_key):
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
         # compute the selection on x required to get the relevant chunk for out_key
         in_sel = selection_function(out_key)
 
         # use a Zarr indexer to convert selection to input coordinates
         indexer = _create_zarr_indexer(in_sel, x.shape, x.chunksize)
 
-        return (iter(tuple((x.name,) + cp.chunk_coords for cp in indexer)),)
+        return (iter(tuple(ChunkKey(x.name, cp.chunk_coords) for cp in indexer)),)
 
     num_input_blocks = (max_num_input_blocks,)
     iterable_input_blocks = (True,)
@@ -1039,7 +1040,7 @@ def _rechunk(x, copy_chunks, target_chunks):
     target_chunks = to_chunksize(target_chunks)
 
     def selection_function(out_key):
-        out_coords = out_key[1:]
+        out_coords = out_key.coords
         return get_item(normalized_copy_chunks, out_coords)
 
     max_num_input_blocks = math.prod(
@@ -1077,7 +1078,7 @@ def merge_chunks(x, chunks):
     target_chunks = normalize_chunks(chunks, x.shape, dtype=x.dtype)
 
     def selection_function(out_key):
-        out_coords = out_key[1:]
+        out_coords = out_key.coords
         return get_item(target_chunks, out_coords)
 
     max_num_input_blocks = math.prod(
@@ -1287,8 +1288,8 @@ def partial_reduce(
     )
     shape = tuple(map(sum, chunks))
 
-    def key_function(out_key):
-        out_coords = out_key[1:]
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        out_coords = out_key.coords
 
         # return a tuple with a single item that is an iterator of input keys to be merged
         in_keys = [
@@ -1300,7 +1301,7 @@ def partial_reduce(
             )
             for i, bi in enumerate(out_coords)
         ]
-        return (iter([(x.name,) + tuple(p) for p in product(*in_keys)]),)
+        return (iter([ChunkKey(x.name, tuple(p)) for p in product(*in_keys)]),)
 
     # Since key_function returns an iterator of input keys, the the array chunks passed to
     # _partial_reduce are retrieved one at a time. However, we need an extra chunk of memory
@@ -1606,12 +1607,15 @@ def scan(
     #    Use general_blockwise with a key function since the chunks of increment and scanned aren't aligned anymore.
     assert increment.shape[axis] == scanned.numblocks[axis]
 
-    def key_function(out_key):
-        out_coords = out_key[1:]
+    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        out_coords = out_key.coords
         inc_coords = tuple(
             bi // split_every if i == axis else bi for i, bi in enumerate(out_coords)
         )
-        return ((scanned.name,) + out_coords, (increment.name,) + inc_coords)
+        return (
+            ChunkKey(scanned.name, out_coords),
+            ChunkKey(increment.name, inc_coords),
+        )
 
     def _scan_binop(scn, inc, block_id=None, **kwargs):
         bi = block_id[axis] % split_every

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -5,7 +5,17 @@ from dataclasses import dataclass
 from functools import partial
 from itertools import product
 from numbers import Integral, Number
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    List,
+    Sequence,
+    Tuple,
+    Union,
+)
 from warnings import warn
 
 import numpy as np
@@ -20,7 +30,7 @@ from cubed.core.array import CoreArray, check_array_specs, gensym
 from cubed.core.array import compute as compute_arrays
 from cubed.core.plan import Plan, intermediate_store
 from cubed.core.rechunk import multistage_regular_rechunking_plan
-from cubed.primitive.blockwise import ChunkKey, FunctionArgs, KeyFunctionResult
+from cubed.primitive.blockwise import ChunkKey, FunctionArgs
 from cubed.primitive.blockwise import blockwise as primitive_blockwise
 from cubed.primitive.blockwise import general_blockwise as primitive_general_blockwise
 from cubed.primitive.memory import get_buffer_copies
@@ -234,7 +244,7 @@ def _store_array(
             for sl, cs in zip(region, chunks)
         ]
 
-        def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+        def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
             out_coords = out_key.coords
             in_coords = tuple(bi - off for bi, off in zip(out_coords, block_offsets))
             return FunctionArgs(
@@ -724,7 +734,7 @@ def map_selection(
         The maximum number of input blocks read from the input array.
     """
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
         # compute the selection on x required to get the relevant chunk for out_key
         in_sel = selection_function(out_key)
 
@@ -1296,7 +1306,7 @@ def partial_reduce(
     )
     shape = tuple(map(sum, chunks))
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
         out_coords = out_key.coords
 
         # return a tuple with a single item that is an iterator of input keys to be merged
@@ -1618,7 +1628,7 @@ def scan(
     #    Use general_blockwise with a key function since the chunks of increment and scanned aren't aligned anymore.
     assert increment.shape[axis] == scanned.numblocks[axis]
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         inc_coords = tuple(
             bi // split_every if i == axis else bi for i, bi in enumerate(out_coords)

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -244,7 +244,7 @@ def _store_array(
             for sl, cs in zip(region, chunks)
         ]
 
-        def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+        def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
             out_coords = out_key.coords
             in_coords = tuple(bi - off for bi, off in zip(out_coords, block_offsets))
             return FunctionArgs(
@@ -273,7 +273,7 @@ def _store_array(
 
         out = general_blockwise(
             identity,
-            key_function,
+            back_key_function,
             source,
             shapes=[shape],
             dtypes=[source.dtype],
@@ -456,7 +456,7 @@ def blockwise(
 
 def general_blockwise(
     func,
-    key_function,
+    back_key_function,
     *arrays,
     shapes,
     dtypes,
@@ -477,12 +477,12 @@ def general_blockwise(
         offsets = offsets_virtual_array(numblocks, array0.spec)
         new_arrays = arrays + (offsets,)
 
-        def key_function_with_offset(key_function):
+        def back_key_function_with_offset(back_key_function):
             def wrap(out_key):
                 out_coords = out_key.coords
                 offset_in_key = (ChunkKey(offsets.name, out_coords),)
                 return FunctionArgs(
-                    *(key_function(out_key).args + offset_in_key),
+                    *(back_key_function(out_key).args + offset_in_key),
                     output_name=out_key.name,
                 )
 
@@ -510,7 +510,7 @@ def general_blockwise(
 
         return _general_blockwise(
             func_with_block_id(func),
-            key_function_with_offset(key_function),
+            back_key_function_with_offset(back_key_function),
             *new_arrays,
             shapes=shapes,
             dtypes=dtypes,
@@ -526,7 +526,7 @@ def general_blockwise(
 
     return _general_blockwise(
         func,
-        key_function,
+        back_key_function,
         *arrays,
         shapes=shapes,
         dtypes=dtypes,
@@ -540,7 +540,7 @@ def general_blockwise(
 
 def _general_blockwise(
     func,
-    key_function,
+    back_key_function,
     *arrays,
     shapes,
     dtypes,
@@ -584,7 +584,7 @@ def _general_blockwise(
 
     op = primitive_general_blockwise(
         func,
-        key_function,
+        back_key_function,
         *zargs,
         allowed_mem=spec.allowed_mem,
         reserved_mem=spec.reserved_mem,
@@ -734,7 +734,7 @@ def map_selection(
         The maximum number of input blocks read from the input array.
     """
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
         # compute the selection on x required to get the relevant chunk for out_key
         in_sel = selection_function(out_key)
 
@@ -751,7 +751,7 @@ def map_selection(
 
     out = general_blockwise(
         _assemble_index_chunk,
-        key_function,
+        back_key_function,
         x,
         shapes=[shape],
         dtypes=[dtype],
@@ -1306,7 +1306,7 @@ def partial_reduce(
     )
     shape = tuple(map(sum, chunks))
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
         out_coords = out_key.coords
 
         # return a tuple with a single item that is an iterator of input keys to be merged
@@ -1324,7 +1324,7 @@ def partial_reduce(
             output_name=out_key.name,
         )
 
-    # Since key_function returns an iterator of input keys, the the array chunks passed to
+    # Since back_key_function returns an iterator of input keys, the the array chunks passed to
     # _partial_reduce are retrieved one at a time. However, we need an extra chunk of memory
     # to stay within limits (maybe because the iterator doesn't free the previous object
     # before getting the next). We also need extra memory to hold two reduced chunks, since
@@ -1333,7 +1333,7 @@ def partial_reduce(
 
     return general_blockwise(
         _partial_reduce,
-        key_function,
+        back_key_function,
         x,
         shapes=[shape],
         dtypes=[dtype],
@@ -1628,7 +1628,7 @@ def scan(
     #    Use general_blockwise with a key function since the chunks of increment and scanned aren't aligned anymore.
     assert increment.shape[axis] == scanned.numblocks[axis]
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         inc_coords = tuple(
             bi // split_every if i == axis else bi for i, bi in enumerate(out_coords)
@@ -1649,7 +1649,7 @@ def scan(
     # 5. Bada-bing, bada-boom.
     out = general_blockwise(
         _scan_binop,
-        key_function,
+        back_key_function,
         scanned,
         increment,
         shapes=[scanned.shape],

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -20,7 +20,7 @@ from cubed.core.array import CoreArray, check_array_specs, gensym
 from cubed.core.array import compute as compute_arrays
 from cubed.core.plan import Plan, intermediate_store
 from cubed.core.rechunk import multistage_regular_rechunking_plan
-from cubed.primitive.blockwise import ChunkKey, ChunkKeyCollection
+from cubed.primitive.blockwise import ChunkKey, FunctionArgs, KeyFunctionResult
 from cubed.primitive.blockwise import blockwise as primitive_blockwise
 from cubed.primitive.blockwise import general_blockwise as primitive_general_blockwise
 from cubed.primitive.memory import get_buffer_copies
@@ -234,10 +234,12 @@ def _store_array(
             for sl, cs in zip(region, chunks)
         ]
 
-        def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+        def key_function(out_key: ChunkKey) -> KeyFunctionResult:
             out_coords = out_key.coords
             in_coords = tuple(bi - off for bi, off in zip(out_coords, block_offsets))
-            return (ChunkKey(source.name, in_coords),)
+            return FunctionArgs(
+                ChunkKey(source.name, in_coords), output_name=out_key.name
+            )
 
         # calculate output block ids from region selection
         indexer = _create_zarr_indexer(region, shape, chunks)
@@ -469,7 +471,10 @@ def general_blockwise(
             def wrap(out_key):
                 out_coords = out_key.coords
                 offset_in_key = (ChunkKey(offsets.name, out_coords),)
-                return key_function(out_key) + offset_in_key
+                return FunctionArgs(
+                    *(key_function(out_key).args + offset_in_key),
+                    output_name=out_key.name,
+                )
 
             return wrap
 
@@ -719,14 +724,17 @@ def map_selection(
         The maximum number of input blocks read from the input array.
     """
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         # compute the selection on x required to get the relevant chunk for out_key
         in_sel = selection_function(out_key)
 
         # use a Zarr indexer to convert selection to input coordinates
         indexer = _create_zarr_indexer(in_sel, x.shape, x.chunksize)
 
-        return (iter(tuple(ChunkKey(x.name, cp.chunk_coords) for cp in indexer)),)
+        return FunctionArgs(
+            iter(tuple(ChunkKey(x.name, cp.chunk_coords) for cp in indexer)),
+            output_name=out_key.name,
+        )
 
     num_input_blocks = (max_num_input_blocks,)
     iterable_input_blocks = (True,)
@@ -1288,7 +1296,7 @@ def partial_reduce(
     )
     shape = tuple(map(sum, chunks))
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         out_coords = out_key.coords
 
         # return a tuple with a single item that is an iterator of input keys to be merged
@@ -1301,7 +1309,10 @@ def partial_reduce(
             )
             for i, bi in enumerate(out_coords)
         ]
-        return (iter([ChunkKey(x.name, tuple(p)) for p in product(*in_keys)]),)
+        return FunctionArgs(
+            iter([ChunkKey(x.name, tuple(p)) for p in product(*in_keys)]),
+            output_name=out_key.name,
+        )
 
     # Since key_function returns an iterator of input keys, the the array chunks passed to
     # _partial_reduce are retrieved one at a time. However, we need an extra chunk of memory
@@ -1607,14 +1618,15 @@ def scan(
     #    Use general_blockwise with a key function since the chunks of increment and scanned aren't aligned anymore.
     assert increment.shape[axis] == scanned.numblocks[axis]
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         out_coords = out_key.coords
         inc_coords = tuple(
             bi // split_every if i == axis else bi for i, bi in enumerate(out_coords)
         )
-        return (
+        return FunctionArgs(
             ChunkKey(scanned.name, out_coords),
             ChunkKey(increment.name, inc_coords),
+            output_name=out_key.name,
         )
 
     def _scan_binop(scn, inc, block_id=None, **kwargs):

--- a/cubed/primitive/DESIGN.md
+++ b/cubed/primitive/DESIGN.md
@@ -1,0 +1,46 @@
+# Blockwise design
+
+_Blockwise_ is a term from Dask that describes a class of functions operating on chunked arrays that map input chunks to output chunks.
+
+Dask has a notation for describing the mapping (which Cubed supports), but the code here generalises this to support an arbitrary mapping.
+
+## Model
+
+* Chunked arrays have names and chunk coordinates.
+* A `ChunkKey` refers to a chunk in an array by name and (a single) coordinate.
+* A blockwise _function_ takes a set of input chunks (possibly from multiple arrays) and produces a set of output chunks (possibly for multiple arrays).
+* A _back key function_ maps a `ChunkKey` in an output array to the input `ChunkKey`s needed for the blockwise _function_.
+* A `BlockwiseOp` has a _back key function_, a blockwise _function_, and the names of the output arrays.
+
+The _back key function_ returns an object that matches the structure of blockwise function, and encodes information about the access pattern for the input chunks.
+
+In particular, a _list_ of `ChunkKey`s indicates that the chunks can be read all at once (e.g. in parallel), whereas an _iterator_ of `ChunkKey`s indicates that the chunks must be read one at a time. This is important for memory management.
+
+### Example: a simple elementwise operation
+
+Consider a simple operation that negates the input. Call the input array `a` and the output `b`.
+
+* The _back key function_ takes a `ChunkKey` and returns a `ChunkKey` with the same coordinates but with a different name (`b` in this case).
+* The _function_ takes a single value (chunk) and returns the negated value (chunk). (The chunk is an array object itself.)
+
+## Application
+
+To use a `BlockwiseOp` to compute output arrays given input arrays, follow this procedure:
+
+* For each chunk in the output arrays, create a `ChunkKey`:
+    * Call the _back key function_ with the `ChunkKey` to find the input `ChunkKey`s.
+    * Read the chunks from the input arrays referred to by the `ChunkKey`s
+    * Call the blockwise _function_ with the chunks to compute the output chunks
+    * Write the output chunks to the output
+
+Note that this procedure can be run in parallel across output chunks.
+
+More generally, a computation may be defined as a DAG, where nodes are arrays or operations (`BlockwiseOp`) and edges are between arrays and operations.
+The above procedure is applied to operations in the DAG in topologically sorted order, so that arrays that are inputs to other arrays are computed before the other arrays.
+
+## Fusion
+
+A `BlockwiseOp` operation can be _fused_ with its predecessor operations by separately fusing the back key functions and the blockwise functions.
+The DAG can be re-written to replace the operations being fused with the single fused operation.
+
+By repeatedly fusing operations in the DAG, it is reduced in size, which helps reduce the amount of IO, since the number of read/write array operations is reduced. However, depending on the nature of the blockwise operations, fusion may increase memory usage, so it must be applied judiciously.

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -109,9 +109,9 @@ class BlockwiseSpec:
 
     Attributes
     ----------
-    back_key_function : Callable
+    back_key_function : Callable[[ChunkKey], FunctionArgs[Any]]
         A function that maps an output chunk key to one or more input chunk keys.
-    function : Callable
+    function : Callable[..., Any]
         A function that maps input chunks to an output chunk.
     num_input_blocks: Tuple[int, ...]
         The number of input blocks read from each input array.

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -52,21 +52,12 @@ def gensym(name: str) -> str:
     return f"{name}-{sym_counter:03}"
 
 
-@dataclass(frozen=True)
-class ChunkKey:
-    """Specifies a chunk in a (named) array by chunk coords."""
-
-    name: str
-    coords: tuple[int, ...]
-
-    def __repr__(self) -> str:
-        return str(self)
-
-    def __str__(self) -> str:
-        return str((self.name,) + self.coords)
-
-
-ChunkKeyCollection = ChunkKey | List[ChunkKey] | Iterator[ChunkKey]
+from blockwise_ng.blockwise import (  # noqa: F401
+    ChunkKey,
+    ChunkKeyCollection,
+    FunctionArgs,
+    KeyFunctionResult,
+)
 
 
 @dataclass(frozen=True)
@@ -98,7 +89,7 @@ class BlockwiseSpec:
         Note that the order of the entries must correspond to the order of the outputs created by the function.
     """
 
-    key_function: Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]]
+    key_function: Callable[[ChunkKey], KeyFunctionResult]
     function: Callable[..., Any]
     function_nargs: int
     num_input_blocks: Tuple[int, ...]
@@ -301,7 +292,7 @@ def blockwise(
 
 def general_blockwise(
     func: Callable[..., Any],
-    key_function: Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]],
+    key_function: Callable[[ChunkKey], KeyFunctionResult],
     *arrays: Any,
     allowed_mem: int,
     reserved_mem: int,
@@ -820,9 +811,9 @@ def fuse_blockwise_specs(
 
 
 def apply_blockwise_key_func(
-    key_function: Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]],
+    key_function: Callable[[ChunkKey], KeyFunctionResult],
     arg: ChunkKeyCollection,
-) -> tuple[ChunkKeyCollection, ...]:
+) -> KeyFunctionResult:
     if isinstance(arg, tuple):
         raise ValueError("Tuples are no longer supported for chunk keys")
     elif isinstance(arg, ChunkKey):
@@ -831,15 +822,20 @@ def apply_blockwise_key_func(
         # more than one input block is being read from arg
         assert isinstance(arg, (list, Iterator))
         if isinstance(arg, list):
-            return tuple(
-                list(item) for item in zip(*(key_function(a) for a in arg), strict=True)
+            return FunctionArgs(
+                *tuple(
+                    list(item)
+                    for item in zip(*(key_function(a) for a in arg), strict=True)
+                )
             )
         else:
             # Return iterators to avoid materializing all array blocks at
             # once.
-            return tuple(
-                iter(list(item))
-                for item in zip(*(key_function(a) for a in arg), strict=True)
+            return FunctionArgs(
+                *tuple(
+                    iter(list(item))
+                    for item in zip(*(key_function(a) for a in arg), strict=True)
+                )
             )
 
 
@@ -855,21 +851,21 @@ def apply_blockwise_func(func, is_iterable, *args):
 
 
 def make_fused_key_function(
-    key_function: Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]],
-    predecessor_key_functions: list[
-        Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]]
-    ],
+    key_function: Callable[[ChunkKey], KeyFunctionResult],
+    predecessor_key_functions: list[Callable[[ChunkKey], KeyFunctionResult]],
     predecessor_funcs_nargs: list[int],
-) -> Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]]:
-    def fused_key_func(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+) -> Callable[[ChunkKey], KeyFunctionResult]:
+    def fused_key_func(out_key: ChunkKey) -> KeyFunctionResult:
         args = key_function(out_key)
         # split all args to the fused function into groups, one for each predecessor function
         func_args = tuple(
             item
             for pkf, a in zip(predecessor_key_functions, args, strict=True)
-            for item in apply_blockwise_key_func(pkf, a)
+            for item in apply_blockwise_key_func(pkf, a).args
         )
-        return tuple(item for item in split_into(func_args, predecessor_funcs_nargs))
+        return FunctionArgs(
+            *tuple(item for item in split_into(func_args, predecessor_funcs_nargs))
+        )
 
     return fused_key_func
 
@@ -976,7 +972,7 @@ def make_blockwise_key_function_flattened(
     *arrind_pairs: Any,
     numblocks: Dict[str, Tuple[int, ...]],
     new_axes: Optional[Dict[int, int]] = None,
-) -> Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]]:
+) -> Callable[[ChunkKey], KeyFunctionResult]:
     # TODO: make this a part of make_blockwise_key_function?
     key_function = make_blockwise_key_function(
         func, output, out_indices, *arrind_pairs, numblocks=numblocks, new_axes=new_axes
@@ -987,6 +983,9 @@ def make_blockwise_key_function_flattened(
         # flatten (nested) lists indicating contraction
         if isinstance(in_keys[0], list):
             in_keys = list(flatten(in_keys))
-        return tuple(ChunkKey(in_key[0], in_key[1:]) for in_key in in_keys)
+        return FunctionArgs(
+            *(ChunkKey(in_key[0], in_key[1:]) for in_key in in_keys),
+            output_name=out_key.name,
+        )
 
     return blockwise_fn_flattened

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -1,11 +1,26 @@
+from __future__ import annotations
+
 import inspect
 import itertools
 import logging
 import math
-from collections.abc import Iterator
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeAlias,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 import toolz
 import zarr
@@ -33,7 +48,6 @@ from cubed.utils import (
     chunk_memory,
     get_item,
     normalize_chunks,
-    split_into,
     to_chunksize,
 )
 from cubed.utils import numblocks as compute_numblocks
@@ -52,11 +66,40 @@ def gensym(name: str) -> str:
     return f"{name}-{sym_counter:03}"
 
 
-from blockwise_ng.blockwise import (  # noqa: F401
-    ChunkKey,
-    ChunkKeyCollection,
-    FunctionArgs,
-)
+@dataclass(frozen=True)
+class ChunkKey:
+    """Specifies a chunk in a (named) array by chunk coords."""
+
+    name: str
+    coords: tuple[int, ...]
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __str__(self) -> str:
+        return str((self.name,) + self.coords)
+
+
+ChunkKeyCollection: TypeAlias = ChunkKey | list[ChunkKey] | Iterator[ChunkKey]
+
+T = TypeVar("T")
+
+
+class FunctionArgs(Generic[T]):
+    def __init__(self, *args: T, output_name: str) -> None:
+        # output_name is the name of the array that the function produces
+        # TODO: will need multiple names for multiple outputs
+        self.args: tuple[T, ...] = args
+        self.output_name = output_name
+
+    def __repr__(self) -> str:
+        return "≪" + ", ".join(repr(v) for v in self.args) + "≫"
+
+    def __str__(self) -> str:
+        return "≪" + ", ".join(str(v) for v in self.args) + "≫"
+
+
+KeyFunction: TypeAlias = Callable[[ChunkKey], FunctionArgs[Any]]
 
 
 @dataclass(frozen=True)
@@ -71,16 +114,10 @@ class BlockwiseSpec:
         A function that maps an output chunk key to one or more input chunk keys.
     function : Callable
         A function that maps input chunks to an output chunk.
-    function_nargs: int
-        The number of array arguments that ``function`` takes. Note that for some
-        functions (``concat``, ``stack``) this may be different to the number of
-        arrays that the operation depends on.
     num_input_blocks: Tuple[int, ...]
         The number of input blocks read from each input array.
     num_output_blocks: Tuple[int, ...]
         The number of output blocks written to each output array.
-    iterable_input_blocks: Tuple[int, ...]
-        Whether the input blocks read from each input array are supplied as an iterable or not.
     reads_map : Dict[str, CubedArrayProxy]
         Read proxy dictionary keyed by array name.
     writes_map : Dict[str, CubedArrayProxy]
@@ -90,10 +127,8 @@ class BlockwiseSpec:
 
     back_key_function: Callable[[ChunkKey], FunctionArgs[Any]]
     function: Callable[..., Any]
-    function_nargs: int
     num_input_blocks: Tuple[int, ...]
     num_output_blocks: Tuple[int, ...]
-    iterable_input_blocks: Tuple[bool, ...]
     reads_map: Dict[str, CubedArrayProxy]
     writes_map: Dict[str, CubedArrayProxy]
     return_writes_stores: bool = False
@@ -143,8 +178,6 @@ def get_results_in_different_scope(out_coords: List[int], *, config: BlockwiseSp
     )  # array name is ignored by back_key_function
     # name_chunk_inds = list(config.back_key_function(out_key))
     # args = map_nested(get_chunk_config, name_chunk_inds)
-
-    from blockwise_ng.blockwise import map_nested
 
     name_chunk_inds = config.back_key_function(out_key)
     fargs = map_nested(get_chunk_config, name_chunk_inds)
@@ -311,7 +344,7 @@ def general_blockwise(
     extra_func_kwargs: Optional[Dict[str, Any]] = None,
     fusable_with_predecessors: bool = True,
     fusable_with_successors: bool = True,
-    function_nargs: Optional[int] = None,
+    function_nargs: Optional[int] = None,  # TODO: redundant
     num_input_blocks: Optional[Tuple[int, ...]] = None,
     iterable_input_blocks: Optional[Tuple[bool, ...]] = None,
     target_chunks_: Optional[T_RegularChunks] = None,
@@ -417,10 +450,8 @@ def general_blockwise(
     spec = BlockwiseSpec(
         back_key_function,
         func_with_kwargs,
-        function_nargs,
         num_input_blocks,
         num_output_blocks,
-        iterable_input_blocks,
         read_proxies,
         write_proxies,
         return_writes_stores,
@@ -516,6 +547,80 @@ def product_from(*iterables, start=0):
                 break
         else:
             return
+
+
+In = TypeVar("In")
+Out = TypeVar("Out")
+
+
+def _map_nested_impl(func: Callable[[Any], Any], seq: Any) -> Any:
+    if isinstance(seq, list):
+        return [_map_nested_impl(func, item) for item in seq]
+    elif isinstance(seq, Iterator):
+        return map(lambda item: _map_nested_impl(func, item), seq)
+    elif isinstance(seq, FunctionArgs):
+        return FunctionArgs(
+            *[_map_nested_impl(func, item) for item in seq.args],
+            output_name=seq.output_name,
+        )
+    else:
+        return func(seq)
+
+
+# Overloads let callers know that a FunctionArgs input always yields a FunctionArgs
+# output (with the mapped leaf type), so .args is accessible without narrowing at
+# the call site and carries the result type Out.
+@overload
+def map_nested(
+    func: Callable[..., Out], seq: FunctionArgs[Any]
+) -> FunctionArgs[Out]: ...
+
+
+@overload
+def map_nested(
+    func: Callable[..., Any],
+    seq: list[Any],
+) -> list[Any]: ...
+
+
+@overload
+def map_nested(
+    func: Callable[..., Any],
+    seq: Iterator[Any],
+) -> Iterator[Any]: ...
+
+
+@overload
+def map_nested(
+    func: Callable[[In], Out],
+    seq: In,
+) -> Out: ...
+
+
+def map_nested(
+    func: Callable[[In], Out],
+    seq: In | list[Any] | Iterator[Any] | FunctionArgs[Any],
+) -> Out | list[Any] | Iterator[Any] | FunctionArgs[Any]:
+    """Apply a function inside nested lists or iterators, while preserving
+    the nesting, and the collection or iterator type.
+
+    Examples
+    --------
+
+    >>> inc = lambda x: x + 1
+    >>> map_nested(inc, [[1, 2], [3, 4]])
+    [[2, 3], [4, 5]]
+
+    >>> it = map_nested(inc, iter([1, 2]))
+    >>> next(it)
+    2
+    >>> next(it)
+    3
+    """
+    result: Out | list[Any] | Iterator[Any] | FunctionArgs[Any] = _map_nested_impl(
+        func, seq
+    )
+    return result
 
 
 # Code for fusing blockwise operations
@@ -642,7 +747,6 @@ def fuse(
     def fused_func(*args):
         return pipeline2.config.function(pipeline1.config.function(*args))
 
-    function_nargs = pipeline1.config.function_nargs
     read_proxies = pipeline1.config.reads_map
     write_proxies = pipeline2.config.writes_map
     return_writes_stores = pipeline2.config.return_writes_stores
@@ -651,14 +755,11 @@ def fuse(
         for n in pipeline1.config.num_input_blocks
     )
     num_output_blocks = pipeline2.config.num_output_blocks
-    iterable_input_blocks = pipeline1.config.iterable_input_blocks
     spec = BlockwiseSpec(
         fused_key_func,
         fused_func,
-        function_nargs,
         num_input_blocks,
         num_output_blocks,
-        iterable_input_blocks,
         read_proxies,
         write_proxies,
         return_writes_stores,
@@ -702,10 +803,8 @@ def fuse_multiple(
     null_blockwise_spec = BlockwiseSpec(
         back_key_function=lambda x: (x,),
         function=lambda x: x,
-        function_nargs=1,
         num_input_blocks=(1,),
         num_output_blocks=(1,),
-        iterable_input_blocks=(False,),
         reads_map={},
         writes_map={},
     )
@@ -758,12 +857,8 @@ def fuse_blockwise_specs(
     Fuse a blockwise spec and its predecessors into a single spec.
     """
 
-    predecessor_funcs_nargs = [bws.function_nargs for bws in predecessor_bw_specs]
-
-    from blockwise_ng.blockwise import make_fused_back_key_function, make_fused_function
-
-    predecessor_back_key_functions_dict = {}
-    predecessor_functions_dict = {}
+    predecessor_back_key_functions_dict: dict[str, KeyFunction] = {}
+    predecessor_functions_dict: dict[str, Callable[..., Any]] = {}
     for bws in predecessor_bw_specs:
         for name in bws.writes_map.keys():
             predecessor_back_key_functions_dict[name] = bws.back_key_function
@@ -774,7 +869,6 @@ def fuse_blockwise_specs(
     )
     fused_func = make_fused_function(bw_spec.function, predecessor_functions_dict)
 
-    fused_function_nargs = bw_spec.function_nargs
     num_input_blocks = bw_spec.num_input_blocks
     predecessor_num_blocks = [bws.num_input_blocks for bws in predecessor_bw_specs]
     # note that the length of fused_num_input_blocks is the same as the number of input arrays
@@ -788,12 +882,6 @@ def fuse_blockwise_specs(
         )
     )
     fused_num_output_blocks = bw_spec.num_output_blocks
-    predecessor_iterable_input_blocks = [
-        bws.iterable_input_blocks for bws in predecessor_bw_specs
-    ]
-    fused_iterable_input_blocks = tuple(
-        itertools.chain(*predecessor_iterable_input_blocks)
-    )
 
     read_proxies = dict(bw_spec.reads_map)
     for bws in predecessor_bw_specs:
@@ -803,10 +891,8 @@ def fuse_blockwise_specs(
     return BlockwiseSpec(
         fused_key_func,
         fused_func,
-        fused_function_nargs,
         fused_num_input_blocks,
         fused_num_output_blocks,
-        fused_iterable_input_blocks,
         read_proxies,
         write_proxies,
         return_writes_stores,
@@ -814,82 +900,114 @@ def fuse_blockwise_specs(
 
 
 def apply_blockwise_key_func(
-    back_key_function: Callable[[ChunkKey], FunctionArgs[Any]],
     arg: ChunkKeyCollection,
+    back_key_functions_dict: dict[str, KeyFunction],
+) -> FunctionArgs[Any] | list[FunctionArgs[Any]] | Iterator[FunctionArgs[Any]]:
+    if isinstance(arg, ChunkKey):
+        return _apply_blockwise_key_func_to_chunk_key(arg, back_key_functions_dict)
+    # more than one input block is being read from arg
+    if isinstance(arg, list):
+        return [
+            FunctionArgs(
+                *_apply_blockwise_key_func_to_chunk_key(
+                    a, back_key_functions_dict
+                ).args,
+                output_name=a.name,
+            )
+            for a in arg
+        ]
+    else:
+        return (
+            FunctionArgs(
+                *_apply_blockwise_key_func_to_chunk_key(
+                    a, back_key_functions_dict
+                ).args,
+                output_name=a.name,
+            )
+            for a in arg
+        )
+
+
+def _apply_blockwise_key_func_to_chunk_key(
+    arg: ChunkKey,
+    back_key_functions_dict: dict[str, KeyFunction],
 ) -> FunctionArgs[Any]:
-    if isinstance(arg, tuple):
-        raise ValueError("Tuples are no longer supported for chunk keys")
-    elif isinstance(arg, ChunkKey):
-        return back_key_function(arg)
-    else:
-        # more than one input block is being read from arg
-        assert isinstance(arg, (list, Iterator))
-        if isinstance(arg, list):
-            return FunctionArgs(
-                *tuple(
-                    list(item)
-                    for item in zip(*(back_key_function(a) for a in arg), strict=True)
-                )
-            )
-        else:
-            # Return iterators to avoid materializing all array blocks at
-            # once.
-            return FunctionArgs(
-                *tuple(
-                    iter(list(item))
-                    for item in zip(*(back_key_function(a) for a in arg), strict=True)
-                )
-            )
-
-
-def apply_blockwise_func(func, is_iterable, *args):
-    if is_iterable is False:
-        ret = func(*args)
-    else:
-        # More than one input block is being read from this group of args to primitive op.
-        # Note that it is important that a list is not returned to avoid materializing all
-        # array blocks at once.
-        ret = map(lambda item: func(*item), zip(*args, strict=True))
-    return ret
+    if arg.name not in back_key_functions_dict:
+        return FunctionArgs(arg, output_name=arg.name)
+    return back_key_functions_dict[arg.name](arg)
 
 
 def make_fused_back_key_function(
-    back_key_function: Callable[[ChunkKey], FunctionArgs[Any]],
-    predecessor_back_key_functions: list[Callable[[ChunkKey], FunctionArgs[Any]]],
-    predecessor_funcs_nargs: list[int],
-) -> Callable[[ChunkKey], FunctionArgs[Any]]:
+    back_key_function: KeyFunction,
+    predecessor_back_key_functions_dict: dict[str, KeyFunction],
+) -> KeyFunction:
     def fused_key_func(out_key: ChunkKey) -> FunctionArgs[Any]:
-        args = back_key_function(out_key)
-        # split all args to the fused function into groups, one for each predecessor function
+        fargs = back_key_function(out_key)
+        args = fargs.args
+
+        # back_key_function is always an unfused function, so its args are
+        # ChunkKeyCollection at runtime. fargs.args is tuple[Any, ...] since
+        # FunctionArgs[Any] is used throughout the key function machinery,
+        # so each a: Any is assignable to ChunkKeyCollection without a cast.
         func_args = tuple(
-            item
-            for pkf, a in zip(predecessor_back_key_functions, args, strict=True)
-            for item in apply_blockwise_key_func(pkf, a).args
+            apply_blockwise_key_func(a, predecessor_back_key_functions_dict)
+            for a in args
         )
-        return FunctionArgs(
-            *tuple(item for item in split_into(func_args, predecessor_funcs_nargs))
-        )
+
+        # note this adds a layer of nesting
+        return FunctionArgs(*func_args, output_name=fargs.output_name)
 
     return fused_key_func
 
 
-def make_fused_function(function, predecessor_functions, iterable_input_blocks):
-    def fused_func_single(*args):
-        # args are grouped appropriately so they can be called by each predecessor function
-        func_args = [
-            apply_blockwise_func(pf, iterable_input_blocks[i], *a)
-            for i, (pf, a) in enumerate(zip(predecessor_functions, args, strict=True))
-        ]
+@overload
+def apply_blockwise_func(
+    arg: FunctionArgs[T],
+    functions_dict: dict[str, Callable[..., T]],
+) -> T: ...
+
+
+@overload
+def apply_blockwise_func(
+    arg: list[FunctionArgs[T]],
+    functions_dict: dict[str, Callable[..., T]],
+) -> list[T]: ...
+
+
+@overload
+def apply_blockwise_func(
+    arg: Iterator[FunctionArgs[T]],
+    functions_dict: dict[str, Callable[..., T]],
+) -> Iterator[T]: ...
+
+
+def apply_blockwise_func(
+    arg: FunctionArgs[T] | list[FunctionArgs[T]] | Iterator[FunctionArgs[T]],
+    functions_dict: dict[str, Callable[..., T]],
+) -> T | list[T] | Iterator[T]:
+    if isinstance(arg, FunctionArgs):
+        if arg.output_name not in functions_dict:
+            return arg.args[0] if len(arg.args) == 1 else list(arg.args)
+        return functions_dict[arg.output_name](*arg.args)
+    # more than one input block is being read from arg
+    if isinstance(arg, list):
+        return [apply_blockwise_func(a, functions_dict) for a in arg]
+    else:
+        return (apply_blockwise_func(a, functions_dict) for a in arg)
+
+
+def make_fused_function(
+    function: Callable[..., T],
+    predecessor_functions_dict: dict[str, Callable[..., T]],
+) -> Callable[..., T]:
+    def fused_func_single(*args: Any) -> T:
+        func_args = [apply_blockwise_func(a, predecessor_functions_dict) for a in args]
         return function(*func_args)
 
-    # multiple outputs
-    def fused_func_generator(*args):
-        # args are grouped appropriately so they can be called by each predecessor function
-        func_args = [
-            apply_blockwise_func(pf, iterable_input_blocks[i], *a)
-            for i, (pf, a) in enumerate(zip(predecessor_functions, args, strict=True))
-        ]
-        yield from function(*func_args)
+    # outer function is a generator (yields multiple outputs)
+    def fused_func_generator(*args: Any) -> Any:
+        func_args = [apply_blockwise_func(a, predecessor_functions_dict) for a in args]
+        yield from cast(Iterable[Any], function(*func_args))
 
     return (
         fused_func_generator

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -795,7 +795,7 @@ def fuse_multiple(
     bw_spec = primitive_op.pipeline.config
 
     null_blockwise_spec = BlockwiseSpec(
-        back_key_function=lambda x: (x,),
+        back_key_function=lambda x: FunctionArgs(x, output_name=x.name),
         function=lambda x: x,
         num_input_blocks=(1,),
         num_output_blocks=(1,),

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -56,7 +56,6 @@ from blockwise_ng.blockwise import (  # noqa: F401
     ChunkKey,
     ChunkKeyCollection,
     FunctionArgs,
-    KeyFunctionResult,
 )
 
 
@@ -89,7 +88,7 @@ class BlockwiseSpec:
         Note that the order of the entries must correspond to the order of the outputs created by the function.
     """
 
-    key_function: Callable[[ChunkKey], KeyFunctionResult]
+    key_function: Callable[[ChunkKey], FunctionArgs[Any]]
     function: Callable[..., Any]
     function_nargs: int
     num_input_blocks: Tuple[int, ...]
@@ -292,7 +291,7 @@ def blockwise(
 
 def general_blockwise(
     func: Callable[..., Any],
-    key_function: Callable[[ChunkKey], KeyFunctionResult],
+    key_function: Callable[[ChunkKey], FunctionArgs[Any]],
     *arrays: Any,
     allowed_mem: int,
     reserved_mem: int,
@@ -811,9 +810,9 @@ def fuse_blockwise_specs(
 
 
 def apply_blockwise_key_func(
-    key_function: Callable[[ChunkKey], KeyFunctionResult],
+    key_function: Callable[[ChunkKey], FunctionArgs[Any]],
     arg: ChunkKeyCollection,
-) -> KeyFunctionResult:
+) -> FunctionArgs[Any]:
     if isinstance(arg, tuple):
         raise ValueError("Tuples are no longer supported for chunk keys")
     elif isinstance(arg, ChunkKey):
@@ -851,11 +850,11 @@ def apply_blockwise_func(func, is_iterable, *args):
 
 
 def make_fused_key_function(
-    key_function: Callable[[ChunkKey], KeyFunctionResult],
-    predecessor_key_functions: list[Callable[[ChunkKey], KeyFunctionResult]],
+    key_function: Callable[[ChunkKey], FunctionArgs[Any]],
+    predecessor_key_functions: list[Callable[[ChunkKey], FunctionArgs[Any]]],
     predecessor_funcs_nargs: list[int],
-) -> Callable[[ChunkKey], KeyFunctionResult]:
-    def fused_key_func(out_key: ChunkKey) -> KeyFunctionResult:
+) -> Callable[[ChunkKey], FunctionArgs[Any]]:
+    def fused_key_func(out_key: ChunkKey) -> FunctionArgs[Any]:
         args = key_function(out_key)
         # split all args to the fused function into groups, one for each predecessor function
         func_args = tuple(
@@ -972,7 +971,7 @@ def make_blockwise_key_function_flattened(
     *arrind_pairs: Any,
     numblocks: Dict[str, Tuple[int, ...]],
     new_axes: Optional[Dict[int, int]] = None,
-) -> Callable[[ChunkKey], KeyFunctionResult]:
+) -> Callable[[ChunkKey], FunctionArgs[Any]]:
     # TODO: make this a part of make_blockwise_key_function?
     key_function = make_blockwise_key_function(
         func, output, out_indices, *arrind_pairs, numblocks=numblocks, new_axes=new_axes

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -67,7 +67,7 @@ class BlockwiseSpec:
 
     Attributes
     ----------
-    key_function : Callable
+    back_key_function : Callable
         A function that maps an output chunk key to one or more input chunk keys.
     function : Callable
         A function that maps input chunks to an output chunk.
@@ -88,7 +88,7 @@ class BlockwiseSpec:
         Note that the order of the entries must correspond to the order of the outputs created by the function.
     """
 
-    key_function: Callable[[ChunkKey], FunctionArgs[Any]]
+    back_key_function: Callable[[ChunkKey], FunctionArgs[Any]]
     function: Callable[..., Any]
     function_nargs: int
     num_input_blocks: Tuple[int, ...]
@@ -138,13 +138,15 @@ def get_results_in_different_scope(out_coords: List[int], *, config: BlockwiseSp
 
     # get array chunks for input keys, preserving any nested list structure
     get_chunk_config = partial(get_chunk, config=config)
-    out_key = ChunkKey("out", out_coords_tuple)  # array name is ignored by key_function
-    # name_chunk_inds = list(config.key_function(out_key))
+    out_key = ChunkKey(
+        "out", out_coords_tuple
+    )  # array name is ignored by back_key_function
+    # name_chunk_inds = list(config.back_key_function(out_key))
     # args = map_nested(get_chunk_config, name_chunk_inds)
 
     from blockwise_ng.blockwise import map_nested
 
-    name_chunk_inds = config.key_function(out_key)
+    name_chunk_inds = config.back_key_function(out_key)
     fargs = map_nested(get_chunk_config, name_chunk_inds)
 
     # return config.function(*args)
@@ -254,7 +256,7 @@ def blockwise(
     for name, ind in zip(array_names, inds, strict=True):
         argindsstr.extend((name, ind))
 
-    key_function = make_blockwise_key_function_flattened(
+    back_key_function = make_blockwise_back_key_function_flattened(
         func,
         target_name,
         out_ind,
@@ -265,7 +267,7 @@ def blockwise(
 
     return general_blockwise(
         func,
-        key_function,
+        back_key_function,
         *arrays,
         allowed_mem=allowed_mem,
         reserved_mem=reserved_mem,
@@ -291,7 +293,7 @@ def blockwise(
 
 def general_blockwise(
     func: Callable[..., Any],
-    key_function: Callable[[ChunkKey], FunctionArgs[Any]],
+    back_key_function: Callable[[ChunkKey], FunctionArgs[Any]],
     *arrays: Any,
     allowed_mem: int,
     reserved_mem: int,
@@ -327,7 +329,7 @@ def general_blockwise(
     ----------
     func : callable
         Function to apply to individual tuples of blocks
-    key_function : callable
+    back_key_function : callable
         A function that maps an output chunk key to one or more input chunk keys.
     *arrays : sequence of Array
         The input arrays.
@@ -413,7 +415,7 @@ def general_blockwise(
     num_output_blocks = (nb,) * len(target_arrays)
 
     spec = BlockwiseSpec(
-        key_function,
+        back_key_function,
         func_with_kwargs,
         function_nargs,
         num_input_blocks,
@@ -633,7 +635,9 @@ def fuse(
     mappable = pipeline2.mappable
 
     def fused_key_func(out_key):
-        return pipeline1.config.key_function(*pipeline2.config.key_function(out_key))
+        return pipeline1.config.back_key_function(
+            *pipeline2.config.back_key_function(out_key)
+        )
 
     def fused_func(*args):
         return pipeline2.config.function(pipeline1.config.function(*args))
@@ -696,7 +700,7 @@ def fuse_multiple(
     bw_spec = primitive_op.pipeline.config
 
     null_blockwise_spec = BlockwiseSpec(
-        key_function=lambda x: (x,),
+        back_key_function=lambda x: (x,),
         function=lambda x: x,
         function_nargs=1,
         num_input_blocks=(1,),
@@ -756,17 +760,17 @@ def fuse_blockwise_specs(
 
     predecessor_funcs_nargs = [bws.function_nargs for bws in predecessor_bw_specs]
 
-    from blockwise_ng.blockwise import make_fused_function, make_fused_key_function
+    from blockwise_ng.blockwise import make_fused_back_key_function, make_fused_function
 
-    predecessor_key_functions_dict = {}
+    predecessor_back_key_functions_dict = {}
     predecessor_functions_dict = {}
     for bws in predecessor_bw_specs:
         for name in bws.writes_map.keys():
-            predecessor_key_functions_dict[name] = bws.key_function
+            predecessor_back_key_functions_dict[name] = bws.back_key_function
             predecessor_functions_dict[name] = bws.function
 
-    fused_key_func = make_fused_key_function(
-        bw_spec.key_function, predecessor_key_functions_dict
+    fused_key_func = make_fused_back_key_function(
+        bw_spec.back_key_function, predecessor_back_key_functions_dict
     )
     fused_func = make_fused_function(bw_spec.function, predecessor_functions_dict)
 
@@ -810,13 +814,13 @@ def fuse_blockwise_specs(
 
 
 def apply_blockwise_key_func(
-    key_function: Callable[[ChunkKey], FunctionArgs[Any]],
+    back_key_function: Callable[[ChunkKey], FunctionArgs[Any]],
     arg: ChunkKeyCollection,
 ) -> FunctionArgs[Any]:
     if isinstance(arg, tuple):
         raise ValueError("Tuples are no longer supported for chunk keys")
     elif isinstance(arg, ChunkKey):
-        return key_function(arg)
+        return back_key_function(arg)
     else:
         # more than one input block is being read from arg
         assert isinstance(arg, (list, Iterator))
@@ -824,7 +828,7 @@ def apply_blockwise_key_func(
             return FunctionArgs(
                 *tuple(
                     list(item)
-                    for item in zip(*(key_function(a) for a in arg), strict=True)
+                    for item in zip(*(back_key_function(a) for a in arg), strict=True)
                 )
             )
         else:
@@ -833,7 +837,7 @@ def apply_blockwise_key_func(
             return FunctionArgs(
                 *tuple(
                     iter(list(item))
-                    for item in zip(*(key_function(a) for a in arg), strict=True)
+                    for item in zip(*(back_key_function(a) for a in arg), strict=True)
                 )
             )
 
@@ -849,17 +853,17 @@ def apply_blockwise_func(func, is_iterable, *args):
     return ret
 
 
-def make_fused_key_function(
-    key_function: Callable[[ChunkKey], FunctionArgs[Any]],
-    predecessor_key_functions: list[Callable[[ChunkKey], FunctionArgs[Any]]],
+def make_fused_back_key_function(
+    back_key_function: Callable[[ChunkKey], FunctionArgs[Any]],
+    predecessor_back_key_functions: list[Callable[[ChunkKey], FunctionArgs[Any]]],
     predecessor_funcs_nargs: list[int],
 ) -> Callable[[ChunkKey], FunctionArgs[Any]]:
     def fused_key_func(out_key: ChunkKey) -> FunctionArgs[Any]:
-        args = key_function(out_key)
+        args = back_key_function(out_key)
         # split all args to the fused function into groups, one for each predecessor function
         func_args = tuple(
             item
-            for pkf, a in zip(predecessor_key_functions, args, strict=True)
+            for pkf, a in zip(predecessor_back_key_functions, args, strict=True)
             for item in apply_blockwise_key_func(pkf, a).args
         )
         return FunctionArgs(
@@ -897,7 +901,7 @@ def make_fused_function(function, predecessor_functions, iterable_input_blocks):
 # blockwise key functions
 
 
-def make_blockwise_key_function(
+def make_blockwise_back_key_function(
     func: Callable[..., Any],
     output: str,
     out_indices: Sequence[Union[str, int]],
@@ -933,7 +937,7 @@ def make_blockwise_key_function(
                     "without specifying drop_axis, or rechunk first."
                 )
 
-    def key_function(out_key: ChunkKey) -> tuple[Any, ...]:
+    def back_key_function(out_key: ChunkKey) -> tuple[Any, ...]:
         out_coords = out_key.coords
 
         # from Dask make_blockwise_graph
@@ -961,10 +965,10 @@ def make_blockwise_key_function(
 
         return val
 
-    return key_function
+    return back_key_function
 
 
-def make_blockwise_key_function_flattened(
+def make_blockwise_back_key_function_flattened(
     func: Callable[..., Any],
     output: str,
     out_indices: Sequence[Union[str, int]],
@@ -972,13 +976,13 @@ def make_blockwise_key_function_flattened(
     numblocks: Dict[str, Tuple[int, ...]],
     new_axes: Optional[Dict[int, int]] = None,
 ) -> Callable[[ChunkKey], FunctionArgs[Any]]:
-    # TODO: make this a part of make_blockwise_key_function?
-    key_function = make_blockwise_key_function(
+    # TODO: make this a part of make_blockwise_back_key_function?
+    back_key_function = make_blockwise_back_key_function(
         func, output, out_indices, *arrind_pairs, numblocks=numblocks, new_axes=new_axes
     )
 
     def blockwise_fn_flattened(out_key):
-        in_keys = key_function(out_key)[1:]  # drop function in position 0
+        in_keys = back_key_function(out_key)[1:]  # drop function in position 0
         # flatten (nested) lists indicating contraction
         if isinstance(in_keys[0], list):
             in_keys = list(flatten(in_keys))

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -227,7 +227,6 @@ def blockwise(
     fusable_with_predecessors: bool = True,
     fusable_with_successors: bool = True,
     num_input_blocks: Optional[Tuple[int, ...]] = None,
-    iterable_input_blocks: Optional[Tuple[bool, ...]] = None,
     **kwargs,
 ) -> PrimitiveOperation:
     """Apply a function to multiple blocks from multiple inputs, expressed using concise indexing rules.
@@ -319,7 +318,6 @@ def blockwise(
         fusable_with_predecessors=fusable_with_predecessors,
         fusable_with_successors=fusable_with_successors,
         num_input_blocks=num_input_blocks,
-        iterable_input_blocks=iterable_input_blocks,
         **kwargs,
     )
 
@@ -345,7 +343,6 @@ def general_blockwise(
     fusable_with_predecessors: bool = True,
     fusable_with_successors: bool = True,
     num_input_blocks: Optional[Tuple[int, ...]] = None,
-    iterable_input_blocks: Optional[Tuple[bool, ...]] = None,
     target_chunks_: Optional[T_RegularChunks] = None,
     return_writes_stores: bool = False,
     output_blocks: Optional[Iterator[List[int]]] = None,
@@ -398,7 +395,6 @@ def general_blockwise(
     func_kwargs = extra_func_kwargs or {}
     func_with_kwargs = partial(func, **{**kwargs, **func_kwargs})
     num_input_blocks = num_input_blocks or (1,) * len(arrays)
-    iterable_input_blocks = iterable_input_blocks or (False,) * len(arrays)
     read_proxies = {
         name: CubedArrayProxy(array, array.chunks) for name, array in array_map.items()
     }

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -88,7 +88,6 @@ T = TypeVar("T")
 class FunctionArgs(Generic[T]):
     def __init__(self, *args: T, output_name: str) -> None:
         # output_name is the name of the array that the function produces
-        # TODO: will need multiple names for multiple outputs
         self.args: tuple[T, ...] = args
         self.output_name = output_name
 

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -175,13 +175,10 @@ def get_results_in_different_scope(out_coords: List[int], *, config: BlockwiseSp
     out_key = ChunkKey(
         "out", out_coords_tuple
     )  # array name is ignored by back_key_function
-    # name_chunk_inds = list(config.back_key_function(out_key))
-    # args = map_nested(get_chunk_config, name_chunk_inds)
 
     name_chunk_inds = config.back_key_function(out_key)
     fargs = map_nested(get_chunk_config, name_chunk_inds)
 
-    # return config.function(*args)
     return config.function(*fargs.args)
 
 

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -732,9 +732,9 @@ def fuse(
 
     mappable = pipeline2.mappable
 
-    def fused_key_func(out_key):
+    def fused_key_func(out_key: ChunkKey) -> FunctionArgs[Any]:
         return pipeline1.config.back_key_function(
-            *pipeline2.config.back_key_function(out_key)
+            pipeline2.config.back_key_function(out_key).args[0]
         )
 
     def fused_func(*args):

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -54,6 +54,23 @@ def gensym(name: str) -> str:
 
 
 @dataclass(frozen=True)
+class ChunkKey:
+    """Specifies a chunk in a (named) array by chunk coords."""
+
+    name: str
+    coords: tuple[int, ...]
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __str__(self) -> str:
+        return str((self.name,) + self.coords)
+
+
+ChunkKeyCollection = ChunkKey | List[ChunkKey] | Iterator[ChunkKey]
+
+
+@dataclass(frozen=True)
 class BlockwiseSpec:
     """Specification for how to run blockwise on an array.
 
@@ -82,7 +99,7 @@ class BlockwiseSpec:
         Note that the order of the entries must correspond to the order of the outputs created by the function.
     """
 
-    key_function: Callable[..., Any]
+    key_function: Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]]
     function: Callable[..., Any]
     function_nargs: int
     num_input_blocks: Tuple[int, ...]
@@ -132,7 +149,7 @@ def get_results_in_different_scope(out_coords: List[int], *, config: BlockwiseSp
 
     # get array chunks for input keys, preserving any nested list structure
     get_chunk_config = partial(get_chunk, config=config)
-    out_key = ("out",) + out_coords_tuple  # array name is ignored by key_function
+    out_key = ChunkKey("out", out_coords_tuple)  # array name is ignored by key_function
     name_chunk_inds = list(config.key_function(out_key))
     args = map_nested(get_chunk_config, name_chunk_inds)
 
@@ -149,8 +166,8 @@ def key_to_slices(
 
 def get_chunk(in_key, config):
     """Read a chunk from the named array"""
-    name = in_key[0]
-    in_coords = in_key[1:]
+    name = in_key.name
+    in_coords = in_key.coords
     arr = config.reads_map[name].open()
     selection = key_to_slices(in_coords, arr)
     arg = arr[selection]
@@ -279,7 +296,7 @@ def blockwise(
 
 def general_blockwise(
     func: Callable[..., Any],
-    key_function: Callable[..., Any],
+    key_function: Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]],
     *arrays: Any,
     allowed_mem: int,
     reserved_mem: int,
@@ -795,8 +812,13 @@ def fuse_blockwise_specs(
     )
 
 
-def apply_blockwise_key_func(key_function, arg):
+def apply_blockwise_key_func(
+    key_function: Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]],
+    arg: ChunkKeyCollection,
+) -> tuple[ChunkKeyCollection, ...]:
     if isinstance(arg, tuple):
+        raise ValueError("Tuples are no longer supported for chunk keys")
+    elif isinstance(arg, ChunkKey):
         return key_function(arg)
     else:
         # more than one input block is being read from arg
@@ -826,9 +848,13 @@ def apply_blockwise_func(func, is_iterable, *args):
 
 
 def make_fused_key_function(
-    key_function, predecessor_key_functions, predecessor_funcs_nargs
-):
-    def fused_key_func(out_key):
+    key_function: Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]],
+    predecessor_key_functions: list[
+        Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]]
+    ],
+    predecessor_funcs_nargs: list[int],
+) -> Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]]:
+    def fused_key_func(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
         args = key_function(out_key)
         # split all args to the fused function into groups, one for each predecessor function
         func_args = tuple(
@@ -836,7 +862,7 @@ def make_fused_key_function(
             for pkf, a in zip(predecessor_key_functions, args, strict=True)
             for item in apply_blockwise_key_func(pkf, a)
         )
-        return split_into(func_args, predecessor_funcs_nargs)
+        return tuple(item for item in split_into(func_args, predecessor_funcs_nargs))
 
     return fused_key_func
 
@@ -876,7 +902,7 @@ def make_blockwise_key_function(
     *arrind_pairs: Any,
     numblocks: Dict[str, Tuple[int, ...]],
     new_axes: Optional[Dict[int, int]] = None,
-) -> Callable[[List[int]], Any]:
+) -> Callable[[ChunkKey], tuple[Any, ...]]:
     """Make a function that is the equivalent of make_blockwise_graph."""
 
     new_axes = new_axes or {}
@@ -905,8 +931,8 @@ def make_blockwise_key_function(
                     "without specifying drop_axis, or rechunk first."
                 )
 
-    def key_function(out_key):
-        out_coords = out_key[1:]
+    def key_function(out_key: ChunkKey) -> tuple[Any, ...]:
+        out_coords = out_key.coords
 
         # from Dask make_blockwise_graph
         deps = set()
@@ -943,7 +969,7 @@ def make_blockwise_key_function_flattened(
     *arrind_pairs: Any,
     numblocks: Dict[str, Tuple[int, ...]],
     new_axes: Optional[Dict[int, int]] = None,
-) -> Callable[[List[int]], Any]:
+) -> Callable[[ChunkKey], tuple[ChunkKeyCollection, ...]]:
     # TODO: make this a part of make_blockwise_key_function?
     key_function = make_blockwise_key_function(
         func, output, out_indices, *arrind_pairs, numblocks=numblocks, new_axes=new_axes
@@ -954,6 +980,6 @@ def make_blockwise_key_function_flattened(
         # flatten (nested) lists indicating contraction
         if isinstance(in_keys[0], list):
             in_keys = list(flatten(in_keys))
-        return in_keys
+        return tuple(ChunkKey(in_key[0], in_key[1:]) for in_key in in_keys)
 
     return blockwise_fn_flattened

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -32,7 +32,6 @@ from cubed.utils import (
     array_memory,
     chunk_memory,
     get_item,
-    map_nested,
     normalize_chunks,
     split_into,
     to_chunksize,
@@ -150,10 +149,16 @@ def get_results_in_different_scope(out_coords: List[int], *, config: BlockwiseSp
     # get array chunks for input keys, preserving any nested list structure
     get_chunk_config = partial(get_chunk, config=config)
     out_key = ChunkKey("out", out_coords_tuple)  # array name is ignored by key_function
-    name_chunk_inds = list(config.key_function(out_key))
-    args = map_nested(get_chunk_config, name_chunk_inds)
+    # name_chunk_inds = list(config.key_function(out_key))
+    # args = map_nested(get_chunk_config, name_chunk_inds)
 
-    return config.function(*args)
+    from blockwise_ng.blockwise import map_nested
+
+    name_chunk_inds = config.key_function(out_key)
+    fargs = map_nested(get_chunk_config, name_chunk_inds)
+
+    # return config.function(*args)
+    return config.function(*fargs.args)
 
 
 def key_to_slices(
@@ -761,17 +766,19 @@ def fuse_blockwise_specs(
 
     predecessor_funcs_nargs = [bws.function_nargs for bws in predecessor_bw_specs]
 
-    fused_key_func = make_fused_key_function(
-        bw_spec.key_function,
-        [bws.key_function for bws in predecessor_bw_specs],
-        predecessor_funcs_nargs,
-    )
+    from blockwise_ng.blockwise import make_fused_function, make_fused_key_function
 
-    fused_func = make_fused_function(
-        bw_spec.function,
-        [bws.function for bws in predecessor_bw_specs],
-        bw_spec.iterable_input_blocks,
+    predecessor_key_functions_dict = {}
+    predecessor_functions_dict = {}
+    for bws in predecessor_bw_specs:
+        for name in bws.writes_map.keys():
+            predecessor_key_functions_dict[name] = bws.key_function
+            predecessor_functions_dict[name] = bws.function
+
+    fused_key_func = make_fused_key_function(
+        bw_spec.key_function, predecessor_key_functions_dict
     )
+    fused_func = make_fused_function(bw_spec.function, predecessor_functions_dict)
 
     fused_function_nargs = bw_spec.function_nargs
     num_input_blocks = bw_spec.num_input_blocks

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -344,7 +344,6 @@ def general_blockwise(
     extra_func_kwargs: Optional[Dict[str, Any]] = None,
     fusable_with_predecessors: bool = True,
     fusable_with_successors: bool = True,
-    function_nargs: Optional[int] = None,  # TODO: redundant
     num_input_blocks: Optional[Tuple[int, ...]] = None,
     iterable_input_blocks: Optional[Tuple[bool, ...]] = None,
     target_chunks_: Optional[T_RegularChunks] = None,
@@ -398,7 +397,6 @@ def general_blockwise(
 
     func_kwargs = extra_func_kwargs or {}
     func_with_kwargs = partial(func, **{**kwargs, **func_kwargs})
-    function_nargs = function_nargs or len(arrays)
     num_input_blocks = num_input_blocks or (1,) * len(arrays)
     iterable_input_blocks = iterable_input_blocks or (False,) * len(arrays)
     read_proxies = {
@@ -872,7 +870,6 @@ def fuse_blockwise_specs(
     num_input_blocks = bw_spec.num_input_blocks
     predecessor_num_blocks = [bws.num_input_blocks for bws in predecessor_bw_specs]
     # note that the length of fused_num_input_blocks is the same as the number of input arrays
-    # but may be different to fused_function_nargs since the fused function groups args
     fused_num_input_blocks = tuple(
         itertools.chain(
             *(

--- a/cubed/tests/primitive/test_blockwise.py
+++ b/cubed/tests/primitive/test_blockwise.py
@@ -5,7 +5,8 @@ from cubed._testing import assert_array_equal
 from cubed.backend_array_api import namespace as nxp
 from cubed.primitive.blockwise import (
     ChunkKey,
-    ChunkKeyCollection,
+    FunctionArgs,
+    KeyFunctionResult,
     blockwise,
     general_blockwise,
     make_blockwise_key_function,
@@ -187,18 +188,18 @@ def test_general_blockwise(tmp_path, executor):
     def merge_chunks(xs):
         return nxp.concat(xs, axis=0)
 
-    def key_function(out_key: ChunkKey) -> tuple[ChunkKeyCollection, ...]:
+    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
         out_coords = out_key.coords
 
         k = merge_factor
         out_coord = out_coords[0]  # this is just 1d
         # return a tuple with a single item that is the list of input keys to be merged
-        return (
+        return FunctionArgs(
             [
                 ChunkKey(in_name, (out_coord * k + i,))
                 for i in range(k)
                 if out_coord * k + i < numblocks
-            ],
+            ]
         )
 
     op = general_blockwise(

--- a/cubed/tests/primitive/test_blockwise.py
+++ b/cubed/tests/primitive/test_blockwise.py
@@ -8,7 +8,7 @@ from cubed.primitive.blockwise import (
     FunctionArgs,
     blockwise,
     general_blockwise,
-    make_blockwise_key_function,
+    make_blockwise_back_key_function,
 )
 from cubed.runtime.executors.local import SingleThreadedExecutor
 from cubed.storage.store import open_storage_array
@@ -187,7 +187,7 @@ def test_general_blockwise(tmp_path, executor):
     def merge_chunks(xs):
         return nxp.concat(xs, axis=0)
 
-    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
 
         k = merge_factor
@@ -203,7 +203,7 @@ def test_general_blockwise(tmp_path, executor):
 
     op = general_blockwise(
         merge_chunks,
-        key_function,
+        back_key_function,
         source,
         allowed_mem=allowed_mem,
         reserved_mem=0,
@@ -246,13 +246,13 @@ def test_blockwise_multiple_outputs(tmp_path, executor):
         yield np.sqrt(x)
         yield -np.sqrt(x)
 
-    def key_function(out_key):
+    def back_key_function(out_key):
         out_coords = out_key.coords
         return (ChunkKey(in_name, out_coords),)
 
     op = general_blockwise(
         sqrts,
-        key_function,
+        back_key_function,
         source,
         allowed_mem=allowed_mem,
         reserved_mem=0,
@@ -308,7 +308,7 @@ def test_blockwise_multiple_outputs_fails_different_numblocks(tmp_path):
         yield np.sqrt(x)
         yield -np.sqrt(x)
 
-    def key_function(out_key):
+    def back_key_function(out_key):
         out_coords = out_key.coords
         return (ChunkKey(in_name, out_coords),)
 
@@ -318,7 +318,7 @@ def test_blockwise_multiple_outputs_fails_different_numblocks(tmp_path):
     ):
         general_blockwise(
             sqrts,
-            key_function,
+            back_key_function,
             source,
             allowed_mem=allowed_mem,
             reserved_mem=0,
@@ -331,10 +331,10 @@ def test_blockwise_multiple_outputs_fails_different_numblocks(tmp_path):
         )
 
 
-def test_make_blockwise_key_function_map():
+def test_make_blockwise_back_key_function_map():
     func = lambda x: 0
 
-    key_fn = make_blockwise_key_function(
+    key_fn = make_blockwise_back_key_function(
         func, "z", "ij", "x", "ij", numblocks={"x": (2, 2)}
     )
 
@@ -342,10 +342,10 @@ def test_make_blockwise_key_function_map():
     check_consistent_with_graph(key_fn, graph)
 
 
-def test_make_blockwise_key_function_elemwise():
+def test_make_blockwise_back_key_function_elemwise():
     func = lambda x: 0
 
-    key_fn = make_blockwise_key_function(
+    key_fn = make_blockwise_back_key_function(
         func, "z", "ij", "x", "ij", "y", "ij", numblocks={"x": (2, 2), "y": (2, 2)}
     )
 
@@ -355,10 +355,10 @@ def test_make_blockwise_key_function_elemwise():
     check_consistent_with_graph(key_fn, graph)
 
 
-def test_make_blockwise_key_function_flip():
+def test_make_blockwise_back_key_function_flip():
     func = lambda x: 0
 
-    key_fn = make_blockwise_key_function(
+    key_fn = make_blockwise_back_key_function(
         func, "z", "ij", "x", "ij", "y", "ji", numblocks={"x": (2, 2), "y": (2, 2)}
     )
 
@@ -368,10 +368,10 @@ def test_make_blockwise_key_function_flip():
     check_consistent_with_graph(key_fn, graph)
 
 
-def test_make_blockwise_key_function_contract():
+def test_make_blockwise_back_key_function_contract():
     func = lambda x: 0
 
-    key_fn = make_blockwise_key_function(
+    key_fn = make_blockwise_back_key_function(
         func, "z", "ik", "x", "ij", "y", "jk", numblocks={"x": (2, 1), "y": (1, 2)}
     )
 
@@ -381,10 +381,10 @@ def test_make_blockwise_key_function_contract():
     check_consistent_with_graph(key_fn, graph)
 
 
-def test_make_blockwise_key_function_contract_1d():
+def test_make_blockwise_back_key_function_contract_1d():
     func = lambda x: 0
 
-    key_fn = make_blockwise_key_function(
+    key_fn = make_blockwise_back_key_function(
         func, "z", "j", "x", "ij", numblocks={"x": (1, 2)}
     )
 
@@ -392,10 +392,10 @@ def test_make_blockwise_key_function_contract_1d():
     check_consistent_with_graph(key_fn, graph)
 
 
-def test_make_blockwise_key_function_contract_0d():
+def test_make_blockwise_back_key_function_contract_0d():
     func = lambda x: 0
 
-    key_fn = make_blockwise_key_function(
+    key_fn = make_blockwise_back_key_function(
         func, "z", "", "x", "ij", numblocks={"x": (1, 1)}
     )
 

--- a/cubed/tests/primitive/test_blockwise.py
+++ b/cubed/tests/primitive/test_blockwise.py
@@ -187,7 +187,7 @@ def test_general_blockwise(tmp_path, executor):
     def merge_chunks(xs):
         return nxp.concat(xs, axis=0)
 
-    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[list[ChunkKey]]:
         out_coords = out_key.coords
 
         k = merge_factor
@@ -198,7 +198,8 @@ def test_general_blockwise(tmp_path, executor):
                 ChunkKey(in_name, (out_coord * k + i,))
                 for i in range(k)
                 if out_coord * k + i < numblocks
-            ]
+            ],
+            output_name=out_key.name,
         )
 
     op = general_blockwise(
@@ -248,7 +249,7 @@ def test_blockwise_multiple_outputs(tmp_path, executor):
 
     def back_key_function(out_key):
         out_coords = out_key.coords
-        return (ChunkKey(in_name, out_coords),)
+        return FunctionArgs(ChunkKey(in_name, out_coords), output_name=out_key.name)
 
     op = general_blockwise(
         sqrts,
@@ -310,7 +311,7 @@ def test_blockwise_multiple_outputs_fails_different_numblocks(tmp_path):
 
     def back_key_function(out_key):
         out_coords = out_key.coords
-        return (ChunkKey(in_name, out_coords),)
+        return FunctionArgs(ChunkKey(in_name, out_coords), output_name=out_key.name)
 
     with pytest.raises(
         ValueError,

--- a/cubed/tests/primitive/test_blockwise.py
+++ b/cubed/tests/primitive/test_blockwise.py
@@ -6,7 +6,6 @@ from cubed.backend_array_api import namespace as nxp
 from cubed.primitive.blockwise import (
     ChunkKey,
     FunctionArgs,
-    KeyFunctionResult,
     blockwise,
     general_blockwise,
     make_blockwise_key_function,
@@ -188,7 +187,7 @@ def test_general_blockwise(tmp_path, executor):
     def merge_chunks(xs):
         return nxp.concat(xs, axis=0)
 
-    def key_function(out_key: ChunkKey) -> KeyFunctionResult:
+    def key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
 
         k = merge_factor

--- a/cubed/tests/primitive/test_blockwise_fusion.py
+++ b/cubed/tests/primitive/test_blockwise_fusion.py
@@ -9,22 +9,22 @@ from cubed.primitive.blockwise import (
     ChunkKey,
     FunctionArgs,
     fuse_blockwise_specs,
-    make_fused_key_function,
+    make_fused_back_key_function,
 )
 from cubed.utils import map_nested
 
 
-def make_map_blocks_key_function(*names):
-    def key_function(out_key: ChunkKey):
+def make_map_blocks_back_key_function(*names):
+    def back_key_function(out_key: ChunkKey):
         out_coords = out_key.coords
         return FunctionArgs(*tuple(ChunkKey(name, out_coords) for name in names))
 
-    return key_function
+    return back_key_function
 
 
-def make_combine_blocks_list_key_function(name, numblocks, split_every):
+def make_combine_blocks_list_back_key_function(name, numblocks, split_every):
     # similar to the key function in partial_reduce
-    def key_function(out_key: ChunkKey):
+    def back_key_function(out_key: ChunkKey):
         out_coords = out_key.coords
 
         # return a tuple with a single item that is a list of input keys to be combined
@@ -39,12 +39,12 @@ def make_combine_blocks_list_key_function(name, numblocks, split_every):
         ]
         return FunctionArgs([ChunkKey(name, tuple(p)) for p in product(*in_keys)])
 
-    return key_function
+    return back_key_function
 
 
-def make_combine_blocks_iter_key_function(name, numblocks, split_every):
+def make_combine_blocks_iter_back_key_function(name, numblocks, split_every):
     # similar to the key function in partial_reduce
-    def key_function(out_key: ChunkKey):
+    def back_key_function(out_key: ChunkKey):
         out_coords = out_key.coords
 
         # return a tuple with a single item that is an iterator of input keys to be combined
@@ -59,23 +59,23 @@ def make_combine_blocks_iter_key_function(name, numblocks, split_every):
         ]
         return FunctionArgs(iter([ChunkKey(name, tuple(p)) for p in product(*in_keys)]))
 
-    return key_function
+    return back_key_function
 
 
-def make_alternate_blocks_key_function(name1, name2):
+def make_alternate_blocks_back_key_function(name1, name2):
     # similar to the key function for stack
-    def key_function(out_key: ChunkKey):
+    def back_key_function(out_key: ChunkKey):
         out_coords = out_key.coords
         index = out_coords[0]  # 1d index
         name = name1 if index % 2 == 0 else name2
         return (ChunkKey(name, out_coords),)
 
-    return key_function
+    return back_key_function
 
 
-def make_concat_blocks_key_function(name1, name2):
+def make_concat_blocks_back_key_function(name1, name2):
     # similar to the key function for concat
-    def key_function(out_key: ChunkKey):
+    def back_key_function(out_key: ChunkKey):
         out_coords = out_key.coords
         index = out_coords[0]  # 1d index
         if index == 0:
@@ -87,7 +87,7 @@ def make_concat_blocks_key_function(name1, name2):
         elif index == 3:
             raise IndexError()
 
-    return key_function
+    return back_key_function
 
 
 def negative(x):
@@ -106,8 +106,8 @@ def sum_iter(x):
     return sum(a for a in x)
 
 
-def check_key_function(key_function, out_coords, expected_str):
-    res = key_function(ChunkKey("out", out_coords))
+def check_back_key_function(back_key_function, out_coords, expected_str):
+    res = back_key_function(ChunkKey("out", out_coords))
     assert isinstance(res, FunctionArgs)
 
     assert str(tuple(iter_repr_nested(r) for r in res.args)) == expected_str
@@ -139,7 +139,7 @@ class IteratorWithRepr(collections.abc.Iterator):
 
 
 def make_blockwise_spec(
-    key_function,
+    back_key_function,
     function,
     function_nargs=1,
     num_input_blocks=(1,),
@@ -147,7 +147,7 @@ def make_blockwise_spec(
     iterable_input_blocks=(False,),
 ):
     return BlockwiseSpec(
-        key_function=key_function,
+        back_key_function=back_key_function,
         function=function,
         function_nargs=function_nargs,
         num_input_blocks=num_input_blocks,
@@ -158,195 +158,217 @@ def make_blockwise_spec(
     )
 
 
-def test_map_blocks_key_function():
-    key_function = make_map_blocks_key_function("a")
+def test_map_blocks_back_key_function():
+    back_key_function = make_map_blocks_back_key_function("a")
 
-    check_key_function(key_function, (0,), "(('a', 0),)")
-    check_key_function(key_function, (1,), "(('a', 1),)")
-
-
-def test_map_blocks_multiple_inputs_key_function():
-    key_function = make_map_blocks_key_function("a", "b")
-
-    check_key_function(key_function, (0,), "(('a', 0), ('b', 0))")
-    check_key_function(key_function, (1,), "(('a', 1), ('b', 1))")
+    check_back_key_function(back_key_function, (0,), "(('a', 0),)")
+    check_back_key_function(back_key_function, (1,), "(('a', 1),)")
 
 
-def test_combine_blocks_list_key_function():
-    key_function = make_combine_blocks_list_key_function(
+def test_map_blocks_multiple_inputs_back_key_function():
+    back_key_function = make_map_blocks_back_key_function("a", "b")
+
+    check_back_key_function(back_key_function, (0,), "(('a', 0), ('b', 0))")
+    check_back_key_function(back_key_function, (1,), "(('a', 1), ('b', 1))")
+
+
+def test_combine_blocks_list_back_key_function():
+    back_key_function = make_combine_blocks_list_back_key_function(
         "a", numblocks=5, split_every=2
     )
 
-    check_key_function(key_function, (0,), "([('a', 0), ('a', 1)],)")
-    check_key_function(key_function, (1,), "([('a', 2), ('a', 3)],)")
-    check_key_function(key_function, (2,), "([('a', 4)],)")
+    check_back_key_function(back_key_function, (0,), "([('a', 0), ('a', 1)],)")
+    check_back_key_function(back_key_function, (1,), "([('a', 2), ('a', 3)],)")
+    check_back_key_function(back_key_function, (2,), "([('a', 4)],)")
 
 
-def test_combine_blocks_iter_key_function():
-    key_function = make_combine_blocks_iter_key_function(
+def test_combine_blocks_iter_back_key_function():
+    back_key_function = make_combine_blocks_iter_back_key_function(
         "a", numblocks=5, split_every=2
     )
 
-    check_key_function(key_function, (0,), "(<('a', 0), ('a', 1)>,)")
-    check_key_function(key_function, (1,), "(<('a', 2), ('a', 3)>,)")
-    check_key_function(key_function, (2,), "(<('a', 4)>,)")
+    check_back_key_function(back_key_function, (0,), "(<('a', 0), ('a', 1)>,)")
+    check_back_key_function(back_key_function, (1,), "(<('a', 2), ('a', 3)>,)")
+    check_back_key_function(back_key_function, (2,), "(<('a', 4)>,)")
 
 
-def test_alternate_blocks_key_function():
-    key_function = make_alternate_blocks_key_function("a", "b")
+def test_alternate_blocks_back_key_function():
+    back_key_function = make_alternate_blocks_back_key_function("a", "b")
 
-    check_key_function(key_function, (0,), "(('a', 0),)")
-    check_key_function(key_function, (1,), "(('b', 1),)")
-    check_key_function(key_function, (2,), "(('a', 2),)")
-    check_key_function(key_function, (3,), "(('b', 3),)")
-
-
-def test_concat_blocks_key_function():
-    key_function = make_concat_blocks_key_function("a", "b")
-
-    check_key_function(key_function, (0,), "(<('a', 0)>,)")
-    check_key_function(key_function, (1,), "(<('a', 1), ('b', 0)>,)")
-    check_key_function(key_function, (2,), "(<('b', 0), ('b', 1)>,)")
+    check_back_key_function(back_key_function, (0,), "(('a', 0),)")
+    check_back_key_function(back_key_function, (1,), "(('b', 1),)")
+    check_back_key_function(back_key_function, (2,), "(('a', 2),)")
+    check_back_key_function(back_key_function, (3,), "(('b', 3),)")
 
 
-def test_fuse_key_function_map_blocks_linear():
-    key_function1 = make_map_blocks_key_function("a")
-    key_function2 = make_map_blocks_key_function("b")
-    key_function3 = make_map_blocks_key_function("c")
-    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
-    fused_key_function = make_fused_key_function(
-        key_function3, [fused_key_function], [1]
+def test_concat_blocks_back_key_function():
+    back_key_function = make_concat_blocks_back_key_function("a", "b")
+
+    check_back_key_function(back_key_function, (0,), "(<('a', 0)>,)")
+    check_back_key_function(back_key_function, (1,), "(<('a', 1), ('b', 0)>,)")
+    check_back_key_function(back_key_function, (2,), "(<('b', 0), ('b', 1)>,)")
+
+
+def test_fuse_back_key_function_map_blocks_linear():
+    back_key_function1 = make_map_blocks_back_key_function("a")
+    back_key_function2 = make_map_blocks_back_key_function("b")
+    back_key_function3 = make_map_blocks_back_key_function("c")
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function2, [back_key_function1], [1]
+    )
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function3, [fused_back_key_function], [1]
     )
 
-    check_key_function(fused_key_function, (0,), "([[('a', 0)]],)")
-    check_key_function(fused_key_function, (1,), "([[('a', 1)]],)")
+    check_back_key_function(fused_back_key_function, (0,), "([[('a', 0)]],)")
+    check_back_key_function(fused_back_key_function, (1,), "([[('a', 1)]],)")
 
 
-def test_fuse_key_function_map_blocks_branching():
-    key_function1 = make_map_blocks_key_function("a", "b")
-    key_function2 = make_map_blocks_key_function("c")
-    key_function3 = make_map_blocks_key_function("d", "e")
-    fused_key_function = make_fused_key_function(
-        key_function3, [key_function1, key_function2], [2, 1]
+def test_fuse_back_key_function_map_blocks_branching():
+    back_key_function1 = make_map_blocks_back_key_function("a", "b")
+    back_key_function2 = make_map_blocks_back_key_function("c")
+    back_key_function3 = make_map_blocks_back_key_function("d", "e")
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function3, [back_key_function1, back_key_function2], [2, 1]
     )
 
-    check_key_function(fused_key_function, (0,), "([('a', 0), ('b', 0)], [('c', 0)])")
-    check_key_function(fused_key_function, (1,), "([('a', 1), ('b', 1)], [('c', 1)])")
+    check_back_key_function(
+        fused_back_key_function, (0,), "([('a', 0), ('b', 0)], [('c', 0)])"
+    )
+    check_back_key_function(
+        fused_back_key_function, (1,), "([('a', 1), ('b', 1)], [('c', 1)])"
+    )
 
 
-def test_fuse_key_function_map_blocks_combine_blocks_list():
-    key_function1 = make_map_blocks_key_function("a")
-    key_function2 = make_combine_blocks_list_key_function(
+def test_fuse_back_key_function_map_blocks_combine_blocks_list():
+    back_key_function1 = make_map_blocks_back_key_function("a")
+    back_key_function2 = make_combine_blocks_list_back_key_function(
         "b", numblocks=5, split_every=2
     )
-    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function2, [back_key_function1], [1]
+    )
 
-    check_key_function(fused_key_function, (0,), "([[('a', 0), ('a', 1)]],)")
-    check_key_function(fused_key_function, (1,), "([[('a', 2), ('a', 3)]],)")
-    check_key_function(fused_key_function, (2,), "([[('a', 4)]],)")
+    check_back_key_function(fused_back_key_function, (0,), "([[('a', 0), ('a', 1)]],)")
+    check_back_key_function(fused_back_key_function, (1,), "([[('a', 2), ('a', 3)]],)")
+    check_back_key_function(fused_back_key_function, (2,), "([[('a', 4)]],)")
 
 
-def test_fuse_key_function_map_blocks_combine_blocks_iter():
-    key_function1 = make_map_blocks_key_function("a")
-    key_function2 = make_combine_blocks_iter_key_function(
+def test_fuse_back_key_function_map_blocks_combine_blocks_iter():
+    back_key_function1 = make_map_blocks_back_key_function("a")
+    back_key_function2 = make_combine_blocks_iter_back_key_function(
         "b", numblocks=5, split_every=2
     )
-    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function2, [back_key_function1], [1]
+    )
 
-    check_key_function(fused_key_function, (0,), "([<('a', 0), ('a', 1)>],)")
-    check_key_function(fused_key_function, (1,), "([<('a', 2), ('a', 3)>],)")
-    check_key_function(fused_key_function, (2,), "([<('a', 4)>],)")
+    check_back_key_function(fused_back_key_function, (0,), "([<('a', 0), ('a', 1)>],)")
+    check_back_key_function(fused_back_key_function, (1,), "([<('a', 2), ('a', 3)>],)")
+    check_back_key_function(fused_back_key_function, (2,), "([<('a', 4)>],)")
 
 
-def test_fuse_key_function_combine_blocks_list_map_blocks():
-    key_function1 = make_combine_blocks_list_key_function(
+def test_fuse_back_key_function_combine_blocks_list_map_blocks():
+    back_key_function1 = make_combine_blocks_list_back_key_function(
         "a", numblocks=5, split_every=2
     )
-    key_function2 = make_map_blocks_key_function("b")
-    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
+    back_key_function2 = make_map_blocks_back_key_function("b")
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function2, [back_key_function1], [1]
+    )
 
-    check_key_function(fused_key_function, (0,), "([[('a', 0), ('a', 1)]],)")
-    check_key_function(fused_key_function, (1,), "([[('a', 2), ('a', 3)]],)")
-    check_key_function(fused_key_function, (2,), "([[('a', 4)]],)")
+    check_back_key_function(fused_back_key_function, (0,), "([[('a', 0), ('a', 1)]],)")
+    check_back_key_function(fused_back_key_function, (1,), "([[('a', 2), ('a', 3)]],)")
+    check_back_key_function(fused_back_key_function, (2,), "([[('a', 4)]],)")
 
 
-def test_fuse_key_function_combine_blocks_iter_map_blocks():
-    key_function1 = make_combine_blocks_iter_key_function(
+def test_fuse_back_key_function_combine_blocks_iter_map_blocks():
+    back_key_function1 = make_combine_blocks_iter_back_key_function(
         "a", numblocks=5, split_every=2
     )
-    key_function2 = make_map_blocks_key_function("b")
-    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
+    back_key_function2 = make_map_blocks_back_key_function("b")
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function2, [back_key_function1], [1]
+    )
 
-    check_key_function(fused_key_function, (0,), "([<('a', 0), ('a', 1)>],)")
-    check_key_function(fused_key_function, (1,), "([<('a', 2), ('a', 3)>],)")
-    check_key_function(fused_key_function, (2,), "([<('a', 4)>],)")
+    check_back_key_function(fused_back_key_function, (0,), "([<('a', 0), ('a', 1)>],)")
+    check_back_key_function(fused_back_key_function, (1,), "([<('a', 2), ('a', 3)>],)")
+    check_back_key_function(fused_back_key_function, (2,), "([<('a', 4)>],)")
 
 
-def test_fuse_key_function_combine_blocks_list_combine_blocks_list():
-    key_function1 = make_combine_blocks_list_key_function(
+def test_fuse_back_key_function_combine_blocks_list_combine_blocks_list():
+    back_key_function1 = make_combine_blocks_list_back_key_function(
         "a", numblocks=5, split_every=2
     )
-    key_function2 = make_combine_blocks_list_key_function(
+    back_key_function2 = make_combine_blocks_list_back_key_function(
         "b", numblocks=3, split_every=2
     )
-    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
-
-    check_key_function(
-        fused_key_function, (0,), "([[[('a', 0), ('a', 1)], [('a', 2), ('a', 3)]]],)"
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function2, [back_key_function1], [1]
     )
-    check_key_function(fused_key_function, (1,), "([[[('a', 4)]]],)")
+
+    check_back_key_function(
+        fused_back_key_function,
+        (0,),
+        "([[[('a', 0), ('a', 1)], [('a', 2), ('a', 3)]]],)",
+    )
+    check_back_key_function(fused_back_key_function, (1,), "([[[('a', 4)]]],)")
 
 
-def test_fuse_key_function_combine_blocks_iter_combine_blocks_iter():
-    key_function1 = make_combine_blocks_iter_key_function(
+def test_fuse_back_key_function_combine_blocks_iter_combine_blocks_iter():
+    back_key_function1 = make_combine_blocks_iter_back_key_function(
         "a", numblocks=5, split_every=2
     )
-    key_function2 = make_combine_blocks_iter_key_function(
+    back_key_function2 = make_combine_blocks_iter_back_key_function(
         "b", numblocks=3, split_every=2
     )
-    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
-
-    check_key_function(
-        fused_key_function, (0,), "([<<('a', 0), ('a', 1)>, <('a', 2), ('a', 3)>>],)"
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function2, [back_key_function1], [1]
     )
-    check_key_function(fused_key_function, (1,), "([<<('a', 4)>>],)")
+
+    check_back_key_function(
+        fused_back_key_function,
+        (0,),
+        "([<<('a', 0), ('a', 1)>, <('a', 2), ('a', 3)>>],)",
+    )
+    check_back_key_function(fused_back_key_function, (1,), "([<<('a', 4)>>],)")
 
 
 @pytest.mark.xfail(reason="https://github.com/cubed-dev/cubed/issues/414")
-def test_fuse_key_function_map_blocks_alternate_blocks_key_function():
-    key_function1 = make_map_blocks_key_function("a")
-    key_function2 = make_map_blocks_key_function("b")
-    key_function3 = make_alternate_blocks_key_function("c", "d")
-    fused_key_function = make_fused_key_function(
-        key_function3, [key_function1, key_function2], [1, 1]
+def test_fuse_back_key_function_map_blocks_alternate_blocks_back_key_function():
+    back_key_function1 = make_map_blocks_back_key_function("a")
+    back_key_function2 = make_map_blocks_back_key_function("b")
+    back_key_function3 = make_alternate_blocks_back_key_function("c", "d")
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function3, [back_key_function1, back_key_function2], [1, 1]
     )
 
-    check_key_function(fused_key_function, (0,), "(('a', 0),)")
-    check_key_function(fused_key_function, (1,), "(('b', 1),)")
-    check_key_function(fused_key_function, (2,), "(('a', 2),)")
-    check_key_function(fused_key_function, (3,), "(('b', 3),)")
+    check_back_key_function(fused_back_key_function, (0,), "(('a', 0),)")
+    check_back_key_function(fused_back_key_function, (1,), "(('b', 1),)")
+    check_back_key_function(fused_back_key_function, (2,), "(('a', 2),)")
+    check_back_key_function(fused_back_key_function, (3,), "(('b', 3),)")
 
 
 @pytest.mark.xfail(reason="https://github.com/cubed-dev/cubed/issues/414")
-def test_fuse_key_function_map_blocks_concat_blocks_key_function():
-    key_function1 = make_map_blocks_key_function("a")
-    key_function2 = make_map_blocks_key_function("b")
-    key_function3 = make_concat_blocks_key_function("c", "d")
-    fused_key_function = make_fused_key_function(
-        key_function3, [key_function1, key_function2], [1, 1]
+def test_fuse_back_key_function_map_blocks_concat_blocks_back_key_function():
+    back_key_function1 = make_map_blocks_back_key_function("a")
+    back_key_function2 = make_map_blocks_back_key_function("b")
+    back_key_function3 = make_concat_blocks_back_key_function("c", "d")
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function3, [back_key_function1, back_key_function2], [1, 1]
     )
 
-    check_key_function(fused_key_function, (0,), "(<('a', 0)>,)")
-    check_key_function(fused_key_function, (1,), "(<('a', 1), ('b', 0)>,)")
-    check_key_function(fused_key_function, (2,), "(<('b', 0), ('b', 1)>,)")
+    check_back_key_function(fused_back_key_function, (0,), "(<('a', 0)>,)")
+    check_back_key_function(fused_back_key_function, (1,), "(<('a', 1), ('b', 0)>,)")
+    check_back_key_function(fused_back_key_function, (2,), "(<('b', 0), ('b', 1)>,)")
 
 
 def apply_blockwise(input_data, out_coords, bw_spec):
     args = []
     out_key = ChunkKey(
         "out", tuple(out_coords)
-    )  # array name is ignored by key_function
-    in_keys = bw_spec.key_function(out_key)
+    )  # array name is ignored by back_key_function
+    in_keys = bw_spec.back_key_function(out_key)
     for in_key in in_keys:
         # just return the (1D) coord as a value
         def get_data(key):
@@ -361,7 +383,7 @@ def apply_blockwise(input_data, out_coords, bw_spec):
 
 def test_apply_blockwise():
     bw_spec = make_blockwise_spec(
-        key_function=make_map_blocks_key_function("a"),
+        back_key_function=make_map_blocks_back_key_function("a"),
         function=negative,
     )
 
@@ -372,7 +394,7 @@ def test_apply_blockwise():
 
 def test_apply_blockwise_multiple_inputs():
     bw_spec = make_blockwise_spec(
-        key_function=make_map_blocks_key_function("a", "b"), function=add
+        back_key_function=make_map_blocks_back_key_function("a", "b"), function=add
     )
 
     input_data = {"a": [0, 1, 2, 3, 4], "b": [5, 6, 7, 8, 9]}
@@ -382,7 +404,7 @@ def test_apply_blockwise_multiple_inputs():
 
 def test_apply_blockwise_iterator():
     bw_spec = make_blockwise_spec(
-        key_function=make_combine_blocks_iter_key_function(
+        back_key_function=make_combine_blocks_iter_back_key_function(
             "a", numblocks=5, split_every=2
         ),
         function=sum_iter,
@@ -395,10 +417,10 @@ def test_apply_blockwise_iterator():
 
 def test_apply_blockwise_fused():
     bw_spec1 = make_blockwise_spec(
-        key_function=make_map_blocks_key_function("a"), function=negative
+        back_key_function=make_map_blocks_back_key_function("a"), function=negative
     )
     bw_spec2 = make_blockwise_spec(
-        key_function=make_map_blocks_key_function("b"), function=negative
+        back_key_function=make_map_blocks_back_key_function("b"), function=negative
     )
 
     bw_spec = fuse_blockwise_specs(bw_spec2, bw_spec1)
@@ -410,10 +432,10 @@ def test_apply_blockwise_fused():
 
 def test_apply_blockwise_fused_iterator():
     bw_spec1 = make_blockwise_spec(
-        key_function=make_map_blocks_key_function("a"), function=negative
+        back_key_function=make_map_blocks_back_key_function("a"), function=negative
     )
     bw_spec2 = make_blockwise_spec(
-        key_function=make_combine_blocks_iter_key_function(
+        back_key_function=make_combine_blocks_iter_back_key_function(
             "b", numblocks=5, split_every=2
         ),
         function=sum_iter,
@@ -430,11 +452,11 @@ def test_apply_blockwise_fused_iterator():
 
 def test_apply_blockwise_fused_iterator_with_single_input_block():
     bw_spec1 = make_blockwise_spec(
-        key_function=make_map_blocks_key_function("a"), function=negative
+        back_key_function=make_map_blocks_back_key_function("a"), function=negative
     )
     # the iterator only reads from a single input block
     bw_spec2 = make_blockwise_spec(
-        key_function=make_combine_blocks_iter_key_function(
+        back_key_function=make_combine_blocks_iter_back_key_function(
             "b", numblocks=5, split_every=1
         ),
         function=sum_iter,

--- a/cubed/tests/primitive/test_blockwise_fusion.py
+++ b/cubed/tests/primitive/test_blockwise_fusion.py
@@ -7,6 +7,7 @@ import pytest
 from cubed.primitive.blockwise import (
     BlockwiseSpec,
     ChunkKey,
+    FunctionArgs,
     fuse_blockwise_specs,
     make_fused_key_function,
 )
@@ -16,7 +17,7 @@ from cubed.utils import map_nested
 def make_map_blocks_key_function(*names):
     def key_function(out_key: ChunkKey):
         out_coords = out_key.coords
-        return tuple(ChunkKey(name, out_coords) for name in names)
+        return FunctionArgs(*tuple(ChunkKey(name, out_coords) for name in names))
 
     return key_function
 
@@ -36,7 +37,7 @@ def make_combine_blocks_list_key_function(name, numblocks, split_every):
             )
             for bi in out_coords
         ]
-        return ([ChunkKey(name, tuple(p)) for p in product(*in_keys)],)
+        return FunctionArgs([ChunkKey(name, tuple(p)) for p in product(*in_keys)])
 
     return key_function
 
@@ -56,7 +57,7 @@ def make_combine_blocks_iter_key_function(name, numblocks, split_every):
             )
             for bi in out_coords
         ]
-        return (iter([ChunkKey(name, tuple(p)) for p in product(*in_keys)]),)
+        return FunctionArgs(iter([ChunkKey(name, tuple(p)) for p in product(*in_keys)]))
 
     return key_function
 
@@ -107,9 +108,9 @@ def sum_iter(x):
 
 def check_key_function(key_function, out_coords, expected_str):
     res = key_function(ChunkKey("out", out_coords))
-    assert isinstance(res, tuple)
+    assert isinstance(res, FunctionArgs)
 
-    assert str(tuple(iter_repr_nested(r) for r in res)) == expected_str
+    assert str(tuple(iter_repr_nested(r) for r in res.args)) == expected_str
 
 
 def iter_repr_nested(seq):

--- a/cubed/tests/primitive/test_blockwise_fusion.py
+++ b/cubed/tests/primitive/test_blockwise_fusion.py
@@ -199,13 +199,14 @@ class IteratorWithRepr(collections.abc.Iterator[T]):
 def make_blockwise_spec(
     back_key_function: KeyFunction,
     function: Callable[..., Any],
+    num_input_blocks: tuple[int, ...] = (1,),
     output_names: set[str] | None = None,
 ) -> BlockwiseSpec:
     output_names = output_names or {"out"}
     return BlockwiseSpec(
         back_key_function=back_key_function,
         function=function,
-        num_input_blocks=(1,),  # not needed for this test
+        num_input_blocks=num_input_blocks,
         num_output_blocks=(1,),  # not needed for this test
         reads_map={},  # not needed for this test
         writes_map={name: None for name in output_names},  # only used for names
@@ -650,6 +651,7 @@ def test_apply_blockwise_alternate_blocks_fused() -> None:
     bw_spec3 = make_blockwise_spec(
         back_key_function=make_alternate_blocks_back_key_function("c", "d"),
         function=identity,
+        num_input_blocks=(1, 1),
     )
 
     bw_spec = fuse_blockwise_specs(bw_spec3, bw_spec1, bw_spec2)
@@ -673,6 +675,7 @@ def test_apply_blockwise_concat_blocks_fused() -> None:
     bw_spec3 = make_blockwise_spec(
         back_key_function=make_concat_blocks_back_key_function("c", "d"),
         function=sum_iter,
+        num_input_blocks=(1, 1),
     )
 
     bw_spec = fuse_blockwise_specs(bw_spec3, bw_spec1, bw_spec2)

--- a/cubed/tests/primitive/test_blockwise_fusion.py
+++ b/cubed/tests/primitive/test_blockwise_fusion.py
@@ -2,6 +2,8 @@ import collections.abc
 from itertools import product
 from typing import Iterator
 
+import pytest
+
 from cubed.primitive.blockwise import (
     BlockwiseSpec,
     ChunkKey,
@@ -55,6 +57,34 @@ def make_combine_blocks_iter_key_function(name, numblocks, split_every):
             for bi in out_coords
         ]
         return (iter([ChunkKey(name, tuple(p)) for p in product(*in_keys)]),)
+
+    return key_function
+
+
+def make_alternate_blocks_key_function(name1, name2):
+    # similar to the key function for stack
+    def key_function(out_key: ChunkKey):
+        out_coords = out_key.coords
+        index = out_coords[0]  # 1d index
+        name = name1 if index % 2 == 0 else name2
+        return (ChunkKey(name, out_coords),)
+
+    return key_function
+
+
+def make_concat_blocks_key_function(name1, name2):
+    # similar to the key function for concat
+    def key_function(out_key: ChunkKey):
+        out_coords = out_key.coords
+        index = out_coords[0]  # 1d index
+        if index == 0:
+            return (iter([ChunkKey(name1, (0,))]),)
+        elif index == 1:
+            return (iter([ChunkKey(name1, (1,)), ChunkKey(name2, (0,))]),)
+        elif index == 2:
+            return (iter([ChunkKey(name2, (0,)), ChunkKey(name2, (1,))]),)
+        elif index == 3:
+            raise IndexError()
 
     return key_function
 
@@ -161,7 +191,61 @@ def test_combine_blocks_iter_key_function():
     check_key_function(key_function, (2,), "(<('a', 4)>,)")
 
 
-def test_fuse_key_function_single_multiple():
+def test_alternate_blocks_key_function():
+    key_function = make_alternate_blocks_key_function("a", "b")
+
+    check_key_function(key_function, (0,), "(('a', 0),)")
+    check_key_function(key_function, (1,), "(('b', 1),)")
+    check_key_function(key_function, (2,), "(('a', 2),)")
+    check_key_function(key_function, (3,), "(('b', 3),)")
+
+
+def test_concat_blocks_key_function():
+    key_function = make_concat_blocks_key_function("a", "b")
+
+    check_key_function(key_function, (0,), "(<('a', 0)>,)")
+    check_key_function(key_function, (1,), "(<('a', 1), ('b', 0)>,)")
+    check_key_function(key_function, (2,), "(<('b', 0), ('b', 1)>,)")
+
+
+def test_fuse_key_function_map_blocks_linear():
+    key_function1 = make_map_blocks_key_function("a")
+    key_function2 = make_map_blocks_key_function("b")
+    key_function3 = make_map_blocks_key_function("c")
+    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
+    fused_key_function = make_fused_key_function(
+        key_function3, [fused_key_function], [1]
+    )
+
+    check_key_function(fused_key_function, (0,), "([[('a', 0)]],)")
+    check_key_function(fused_key_function, (1,), "([[('a', 1)]],)")
+
+
+def test_fuse_key_function_map_blocks_branching():
+    key_function1 = make_map_blocks_key_function("a", "b")
+    key_function2 = make_map_blocks_key_function("c")
+    key_function3 = make_map_blocks_key_function("d", "e")
+    fused_key_function = make_fused_key_function(
+        key_function3, [key_function1, key_function2], [2, 1]
+    )
+
+    check_key_function(fused_key_function, (0,), "([('a', 0), ('b', 0)], [('c', 0)])")
+    check_key_function(fused_key_function, (1,), "([('a', 1), ('b', 1)], [('c', 1)])")
+
+
+def test_fuse_key_function_map_blocks_combine_blocks_list():
+    key_function1 = make_map_blocks_key_function("a")
+    key_function2 = make_combine_blocks_list_key_function(
+        "b", numblocks=5, split_every=2
+    )
+    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
+
+    check_key_function(fused_key_function, (0,), "([[('a', 0), ('a', 1)]],)")
+    check_key_function(fused_key_function, (1,), "([[('a', 2), ('a', 3)]],)")
+    check_key_function(fused_key_function, (2,), "([[('a', 4)]],)")
+
+
+def test_fuse_key_function_map_blocks_combine_blocks_iter():
     key_function1 = make_map_blocks_key_function("a")
     key_function2 = make_combine_blocks_iter_key_function(
         "b", numblocks=5, split_every=2
@@ -173,7 +257,19 @@ def test_fuse_key_function_single_multiple():
     check_key_function(fused_key_function, (2,), "([<('a', 4)>],)")
 
 
-def test_fuse_key_function_multiple_single():
+def test_fuse_key_function_combine_blocks_list_map_blocks():
+    key_function1 = make_combine_blocks_list_key_function(
+        "a", numblocks=5, split_every=2
+    )
+    key_function2 = make_map_blocks_key_function("b")
+    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
+
+    check_key_function(fused_key_function, (0,), "([[('a', 0), ('a', 1)]],)")
+    check_key_function(fused_key_function, (1,), "([[('a', 2), ('a', 3)]],)")
+    check_key_function(fused_key_function, (2,), "([[('a', 4)]],)")
+
+
+def test_fuse_key_function_combine_blocks_iter_map_blocks():
     key_function1 = make_combine_blocks_iter_key_function(
         "a", numblocks=5, split_every=2
     )
@@ -185,7 +281,22 @@ def test_fuse_key_function_multiple_single():
     check_key_function(fused_key_function, (2,), "([<('a', 4)>],)")
 
 
-def test_fuse_key_function_multiple_multiple():
+def test_fuse_key_function_combine_blocks_list_combine_blocks_list():
+    key_function1 = make_combine_blocks_list_key_function(
+        "a", numblocks=5, split_every=2
+    )
+    key_function2 = make_combine_blocks_list_key_function(
+        "b", numblocks=3, split_every=2
+    )
+    fused_key_function = make_fused_key_function(key_function2, [key_function1], [1])
+
+    check_key_function(
+        fused_key_function, (0,), "([[[('a', 0), ('a', 1)], [('a', 2), ('a', 3)]]],)"
+    )
+    check_key_function(fused_key_function, (1,), "([[[('a', 4)]]],)")
+
+
+def test_fuse_key_function_combine_blocks_iter_combine_blocks_iter():
     key_function1 = make_combine_blocks_iter_key_function(
         "a", numblocks=5, split_every=2
     )
@@ -198,6 +309,35 @@ def test_fuse_key_function_multiple_multiple():
         fused_key_function, (0,), "([<<('a', 0), ('a', 1)>, <('a', 2), ('a', 3)>>],)"
     )
     check_key_function(fused_key_function, (1,), "([<<('a', 4)>>],)")
+
+
+@pytest.mark.xfail(reason="https://github.com/cubed-dev/cubed/issues/414")
+def test_fuse_key_function_map_blocks_alternate_blocks_key_function():
+    key_function1 = make_map_blocks_key_function("a")
+    key_function2 = make_map_blocks_key_function("b")
+    key_function3 = make_alternate_blocks_key_function("c", "d")
+    fused_key_function = make_fused_key_function(
+        key_function3, [key_function1, key_function2], [1, 1]
+    )
+
+    check_key_function(fused_key_function, (0,), "(('a', 0),)")
+    check_key_function(fused_key_function, (1,), "(('b', 1),)")
+    check_key_function(fused_key_function, (2,), "(('a', 2),)")
+    check_key_function(fused_key_function, (3,), "(('b', 3),)")
+
+
+@pytest.mark.xfail(reason="https://github.com/cubed-dev/cubed/issues/414")
+def test_fuse_key_function_map_blocks_concat_blocks_key_function():
+    key_function1 = make_map_blocks_key_function("a")
+    key_function2 = make_map_blocks_key_function("b")
+    key_function3 = make_concat_blocks_key_function("c", "d")
+    fused_key_function = make_fused_key_function(
+        key_function3, [key_function1, key_function2], [1, 1]
+    )
+
+    check_key_function(fused_key_function, (0,), "(<('a', 0)>,)")
+    check_key_function(fused_key_function, (1,), "(<('a', 1), ('b', 0)>,)")
+    check_key_function(fused_key_function, (2,), "(<('b', 0), ('b', 1)>,)")
 
 
 def apply_blockwise(input_data, out_coords, bw_spec):

--- a/cubed/tests/primitive/test_blockwise_fusion.py
+++ b/cubed/tests/primitive/test_blockwise_fusion.py
@@ -1,30 +1,41 @@
 import collections.abc
+import logging
+import math
+from collections.abc import Callable, Iterable, Iterator
 from itertools import product
-from typing import Iterator
-
-import pytest
+from typing import Any, TypeVar
 
 from cubed.primitive.blockwise import (
     BlockwiseSpec,
     ChunkKey,
     FunctionArgs,
+    KeyFunction,
     fuse_blockwise_specs,
     make_fused_back_key_function,
+    map_nested,
 )
-from cubed.utils import map_nested
+
+logger = logging.getLogger(__name__)
 
 
-def make_map_blocks_back_key_function(*names):
-    def back_key_function(out_key: ChunkKey):
+def make_map_blocks_back_key_function(
+    *names: str,
+) -> Callable[[ChunkKey], FunctionArgs[ChunkKey]]:
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
-        return FunctionArgs(*tuple(ChunkKey(name, out_coords) for name in names))
+        return FunctionArgs(
+            *tuple(ChunkKey(name, out_coords) for name in names),
+            output_name=out_key.name,
+        )
 
     return back_key_function
 
 
-def make_combine_blocks_list_back_key_function(name, numblocks, split_every):
+def make_combine_blocks_list_back_key_function(
+    name: str, numblocks: int, split_every: int
+) -> Callable[[ChunkKey], FunctionArgs[list[ChunkKey]]]:
     # similar to the key function in partial_reduce
-    def back_key_function(out_key: ChunkKey):
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[list[ChunkKey]]:
         out_coords = out_key.coords
 
         # return a tuple with a single item that is a list of input keys to be combined
@@ -37,17 +48,23 @@ def make_combine_blocks_list_back_key_function(name, numblocks, split_every):
             )
             for bi in out_coords
         ]
-        return FunctionArgs([ChunkKey(name, tuple(p)) for p in product(*in_keys)])
+        return FunctionArgs(
+            [ChunkKey(name, tuple(p)) for p in product(*in_keys)],
+            output_name=out_key.name,
+        )
 
     return back_key_function
 
 
-def make_combine_blocks_iter_back_key_function(name, numblocks, split_every):
+def make_combine_blocks_iter_back_key_function(
+    name: str, numblocks: int, split_every: int
+) -> Callable[[ChunkKey], FunctionArgs[Iterator[ChunkKey]]]:
     # similar to the key function in partial_reduce
-    def back_key_function(out_key: ChunkKey):
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
         out_coords = out_key.coords
 
-        # return a tuple with a single item that is an iterator of input keys to be combined
+        # return a tuple with a single item that is an iterator of input keys
+        # to be combined
         in_keys = [
             list(
                 range(
@@ -57,246 +74,318 @@ def make_combine_blocks_iter_back_key_function(name, numblocks, split_every):
             )
             for bi in out_coords
         ]
-        return FunctionArgs(iter([ChunkKey(name, tuple(p)) for p in product(*in_keys)]))
+        return FunctionArgs(
+            iter([ChunkKey(name, tuple(p)) for p in product(*in_keys)]),
+            output_name=out_key.name,
+        )
 
     return back_key_function
 
 
-def make_alternate_blocks_back_key_function(name1, name2):
+def make_alternate_blocks_back_key_function(
+    name1: str, name2: str
+) -> Callable[[ChunkKey], FunctionArgs[ChunkKey]]:
     # similar to the key function for stack
-    def back_key_function(out_key: ChunkKey):
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[ChunkKey]:
         out_coords = out_key.coords
         index = out_coords[0]  # 1d index
         name = name1 if index % 2 == 0 else name2
-        return (ChunkKey(name, out_coords),)
+        return FunctionArgs(ChunkKey(name, out_coords), output_name=out_key.name)
 
     return back_key_function
 
 
-def make_concat_blocks_back_key_function(name1, name2):
+def make_concat_blocks_back_key_function(
+    name1: str, name2: str
+) -> Callable[[ChunkKey], FunctionArgs[Iterator[ChunkKey]]]:
     # similar to the key function for concat
-    def back_key_function(out_key: ChunkKey):
+    def back_key_function(out_key: ChunkKey) -> FunctionArgs[Iterator[ChunkKey]]:
         out_coords = out_key.coords
         index = out_coords[0]  # 1d index
         if index == 0:
-            return (iter([ChunkKey(name1, (0,))]),)
+            it = iter([ChunkKey(name1, (0,))])
         elif index == 1:
-            return (iter([ChunkKey(name1, (1,)), ChunkKey(name2, (0,))]),)
+            it = iter([ChunkKey(name1, (1,)), ChunkKey(name2, (0,))])
         elif index == 2:
-            return (iter([ChunkKey(name2, (0,)), ChunkKey(name2, (1,))]),)
-        elif index == 3:
+            it = iter([ChunkKey(name2, (0,)), ChunkKey(name2, (1,))])
+        elif index > 2:
             raise IndexError()
+        return FunctionArgs(it, output_name=out_key.name)
 
     return back_key_function
 
 
-def negative(x):
+def identity(x: int) -> int:
+    logger.debug(f"identity({x})")
+    return x
+
+
+def negative(x: int) -> int:
+    logger.debug(f"negative({x})")
     assert isinstance(x, int)
     return -x
 
 
-def add(x, y):
+def add(x: int, y: int) -> int:
+    logger.debug(f"add({x}, {y})")
     assert isinstance(x, int)
     assert isinstance(y, int)
     return x + y
 
 
-def sum_iter(x):
+def sum_iter(x: Iterator[int]) -> int:
+    logger.debug(f"sum_iter({x})")
     assert isinstance(x, Iterator)
     return sum(a for a in x)
 
 
-def check_back_key_function(back_key_function, out_coords, expected_str):
+def sum_list(x: list[int]) -> int:
+    logger.debug(f"sum_list({x})")
+    assert isinstance(x, list)
+    return sum(a for a in x)
+
+
+def int_sqrts(x: int) -> Iterator[int]:
+    logger.debug(f"int_sqrts({x})")
+    assert isinstance(x, int)
+    s = int(math.sqrt(x))
+    yield s
+    yield -s
+
+
+def check_back_key_function(
+    back_key_function: KeyFunction,
+    out_coords: tuple[int, ...],
+    expected_str: str,
+) -> None:
     res = back_key_function(ChunkKey("out", out_coords))
     assert isinstance(res, FunctionArgs)
 
-    assert str(tuple(iter_repr_nested(r) for r in res.args)) == expected_str
+    assert str(iter_repr_nested(res)) == expected_str
 
 
-def iter_repr_nested(seq):
+def iter_repr_nested(seq: Any) -> Any:
     # convert nested iterators to lists
     if isinstance(seq, list):
         return [iter_repr_nested(item) for item in seq]
+    elif isinstance(seq, FunctionArgs):
+        return FunctionArgs(
+            *[iter_repr_nested(item) for item in seq.args], output_name=seq.output_name
+        )
     elif isinstance(seq, Iterator):
         return IteratorWithRepr([iter_repr_nested(item) for item in seq])
     else:
         return seq
 
 
-class IteratorWithRepr(collections.abc.Iterator):
-    def __init__(self, values):
+T = TypeVar("T")
+
+
+class IteratorWithRepr(collections.abc.Iterator[T]):
+    def __init__(self, values: Iterable[T]):
         self.values = values
         self.it = iter(values)
 
-    def __next__(self):
+    def __next__(self) -> T:
         return next(self.it)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<" + ", ".join(repr(v) for v in self.values) + ">"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "<" + ", ".join(str(v) for v in self.values) + ">"
 
 
 def make_blockwise_spec(
-    back_key_function,
-    function,
-    function_nargs=1,
-    num_input_blocks=(1,),
-    num_output_blocks=(1,),
-    iterable_input_blocks=(False,),
-):
+    back_key_function: KeyFunction,
+    function: Callable[..., Any],
+    output_names: set[str] | None = None,
+) -> BlockwiseSpec:
     return BlockwiseSpec(
         back_key_function=back_key_function,
         function=function,
-        function_nargs=function_nargs,
-        num_input_blocks=num_input_blocks,
-        num_output_blocks=num_output_blocks,
-        iterable_input_blocks=iterable_input_blocks,
-        reads_map={},  # unused
-        writes_map={},  # unused
+        output_names=output_names or {"out"},
     )
 
 
-def test_map_blocks_back_key_function():
+def test_map_blocks_back_key_function() -> None:
     back_key_function = make_map_blocks_back_key_function("a")
 
-    check_back_key_function(back_key_function, (0,), "(('a', 0),)")
-    check_back_key_function(back_key_function, (1,), "(('a', 1),)")
+    check_back_key_function(back_key_function, (0,), "≪('a', 0)≫")
+    check_back_key_function(back_key_function, (1,), "≪('a', 1)≫")
 
 
-def test_map_blocks_multiple_inputs_back_key_function():
+def test_map_blocks_multiple_inputs_back_key_function() -> None:
     back_key_function = make_map_blocks_back_key_function("a", "b")
 
-    check_back_key_function(back_key_function, (0,), "(('a', 0), ('b', 0))")
-    check_back_key_function(back_key_function, (1,), "(('a', 1), ('b', 1))")
+    check_back_key_function(back_key_function, (0,), "≪('a', 0), ('b', 0)≫")
+    check_back_key_function(back_key_function, (1,), "≪('a', 1), ('b', 1)≫")
 
 
-def test_combine_blocks_list_back_key_function():
+def test_combine_blocks_list_back_key_function() -> None:
     back_key_function = make_combine_blocks_list_back_key_function(
         "a", numblocks=5, split_every=2
     )
 
-    check_back_key_function(back_key_function, (0,), "([('a', 0), ('a', 1)],)")
-    check_back_key_function(back_key_function, (1,), "([('a', 2), ('a', 3)],)")
-    check_back_key_function(back_key_function, (2,), "([('a', 4)],)")
+    check_back_key_function(back_key_function, (0,), "≪[('a', 0), ('a', 1)]≫")
+    check_back_key_function(back_key_function, (1,), "≪[('a', 2), ('a', 3)]≫")
+    check_back_key_function(back_key_function, (2,), "≪[('a', 4)]≫")
 
 
-def test_combine_blocks_iter_back_key_function():
+def test_combine_blocks_iter_back_key_function() -> None:
     back_key_function = make_combine_blocks_iter_back_key_function(
         "a", numblocks=5, split_every=2
     )
 
-    check_back_key_function(back_key_function, (0,), "(<('a', 0), ('a', 1)>,)")
-    check_back_key_function(back_key_function, (1,), "(<('a', 2), ('a', 3)>,)")
-    check_back_key_function(back_key_function, (2,), "(<('a', 4)>,)")
+    check_back_key_function(back_key_function, (0,), "≪<('a', 0), ('a', 1)>≫")
+    check_back_key_function(back_key_function, (1,), "≪<('a', 2), ('a', 3)>≫")
+    check_back_key_function(back_key_function, (2,), "≪<('a', 4)>≫")
 
 
-def test_alternate_blocks_back_key_function():
+def test_alternate_blocks_back_key_function() -> None:
     back_key_function = make_alternate_blocks_back_key_function("a", "b")
 
-    check_back_key_function(back_key_function, (0,), "(('a', 0),)")
-    check_back_key_function(back_key_function, (1,), "(('b', 1),)")
-    check_back_key_function(back_key_function, (2,), "(('a', 2),)")
-    check_back_key_function(back_key_function, (3,), "(('b', 3),)")
+    check_back_key_function(back_key_function, (0,), "≪('a', 0)≫")
+    check_back_key_function(back_key_function, (1,), "≪('b', 1)≫")
+    check_back_key_function(back_key_function, (2,), "≪('a', 2)≫")
+    check_back_key_function(back_key_function, (3,), "≪('b', 3)≫")
 
 
-def test_concat_blocks_back_key_function():
+def test_concat_blocks_back_key_function() -> None:
     back_key_function = make_concat_blocks_back_key_function("a", "b")
 
-    check_back_key_function(back_key_function, (0,), "(<('a', 0)>,)")
-    check_back_key_function(back_key_function, (1,), "(<('a', 1), ('b', 0)>,)")
-    check_back_key_function(back_key_function, (2,), "(<('b', 0), ('b', 1)>,)")
+    check_back_key_function(back_key_function, (0,), "≪<('a', 0)>≫")
+    check_back_key_function(back_key_function, (1,), "≪<('a', 1), ('b', 0)>≫")
+    check_back_key_function(back_key_function, (2,), "≪<('b', 0), ('b', 1)>≫")
 
 
-def test_fuse_back_key_function_map_blocks_linear():
+def test_fuse_back_key_function_map_blocks_linear() -> None:
+    #
+    #   a
+    #   |
+    #   b
+    #   |
+    #   c
+    #   |
+    #  out
+    #
     back_key_function1 = make_map_blocks_back_key_function("a")
     back_key_function2 = make_map_blocks_back_key_function("b")
     back_key_function3 = make_map_blocks_back_key_function("c")
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function2, [back_key_function1], [1]
+        back_key_function2, {"b": back_key_function1}
     )
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function3, [fused_back_key_function], [1]
+        back_key_function3, {"c": fused_back_key_function}
     )
 
-    check_back_key_function(fused_back_key_function, (0,), "([[('a', 0)]],)")
-    check_back_key_function(fused_back_key_function, (1,), "([[('a', 1)]],)")
+    check_back_key_function(fused_back_key_function, (0,), "≪≪≪('a', 0)≫≫≫")
+    check_back_key_function(fused_back_key_function, (1,), "≪≪≪('a', 1)≫≫≫")
 
 
-def test_fuse_back_key_function_map_blocks_branching():
+def test_fuse_back_key_function_map_blocks_branching() -> None:
+    #
+    #  a   b c
+    #   \ /  |
+    #    d   e
+    #     \ /
+    #     out
+    #
     back_key_function1 = make_map_blocks_back_key_function("a", "b")
     back_key_function2 = make_map_blocks_back_key_function("c")
     back_key_function3 = make_map_blocks_back_key_function("d", "e")
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function3, [back_key_function1, back_key_function2], [2, 1]
+        back_key_function3, {"d": back_key_function1, "e": back_key_function2}
     )
 
     check_back_key_function(
-        fused_back_key_function, (0,), "([('a', 0), ('b', 0)], [('c', 0)])"
+        fused_back_key_function, (0,), "≪≪('a', 0), ('b', 0)≫, ≪('c', 0)≫≫"
     )
     check_back_key_function(
-        fused_back_key_function, (1,), "([('a', 1), ('b', 1)], [('c', 1)])"
+        fused_back_key_function, (1,), "≪≪('a', 1), ('b', 1)≫, ≪('c', 1)≫≫"
     )
 
 
-def test_fuse_back_key_function_map_blocks_combine_blocks_list():
+def test_fuse_back_key_function_map_blocks_branching_mixed_levels() -> None:
+    #
+    #  a   b
+    #   \ /
+    #    c   d
+    #     \ /
+    #     out
+    #
+    back_key_function1 = make_map_blocks_back_key_function("a", "b")
+    back_key_function2 = make_map_blocks_back_key_function("c", "d")
+    fused_back_key_function = make_fused_back_key_function(
+        back_key_function2, {"c": back_key_function1}
+    )
+
+    # note that d is wrapped in a function (the identity)
+    check_back_key_function(
+        fused_back_key_function, (0,), "≪≪('a', 0), ('b', 0)≫, ≪('d', 0)≫≫"
+    )
+    check_back_key_function(
+        fused_back_key_function, (1,), "≪≪('a', 1), ('b', 1)≫, ≪('d', 1)≫≫"
+    )
+
+
+def test_fuse_back_key_function_map_blocks_combine_blocks_list() -> None:
     back_key_function1 = make_map_blocks_back_key_function("a")
     back_key_function2 = make_combine_blocks_list_back_key_function(
         "b", numblocks=5, split_every=2
     )
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function2, [back_key_function1], [1]
+        back_key_function2, {"b": back_key_function1}
     )
 
-    check_back_key_function(fused_back_key_function, (0,), "([[('a', 0), ('a', 1)]],)")
-    check_back_key_function(fused_back_key_function, (1,), "([[('a', 2), ('a', 3)]],)")
-    check_back_key_function(fused_back_key_function, (2,), "([[('a', 4)]],)")
+    check_back_key_function(fused_back_key_function, (0,), "≪[≪('a', 0)≫, ≪('a', 1)≫]≫")
+    check_back_key_function(fused_back_key_function, (1,), "≪[≪('a', 2)≫, ≪('a', 3)≫]≫")
+    check_back_key_function(fused_back_key_function, (2,), "≪[≪('a', 4)≫]≫")
 
 
-def test_fuse_back_key_function_map_blocks_combine_blocks_iter():
+def test_fuse_back_key_function_map_blocks_combine_blocks_iter() -> None:
     back_key_function1 = make_map_blocks_back_key_function("a")
     back_key_function2 = make_combine_blocks_iter_back_key_function(
         "b", numblocks=5, split_every=2
     )
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function2, [back_key_function1], [1]
+        back_key_function2, {"b": back_key_function1}
     )
 
-    check_back_key_function(fused_back_key_function, (0,), "([<('a', 0), ('a', 1)>],)")
-    check_back_key_function(fused_back_key_function, (1,), "([<('a', 2), ('a', 3)>],)")
-    check_back_key_function(fused_back_key_function, (2,), "([<('a', 4)>],)")
+    check_back_key_function(fused_back_key_function, (0,), "≪<≪('a', 0)≫, ≪('a', 1)≫>≫")
+    check_back_key_function(fused_back_key_function, (1,), "≪<≪('a', 2)≫, ≪('a', 3)≫>≫")
+    check_back_key_function(fused_back_key_function, (2,), "≪<≪('a', 4)≫>≫")
 
 
-def test_fuse_back_key_function_combine_blocks_list_map_blocks():
+def test_fuse_back_key_function_combine_blocks_list_map_blocks() -> None:
     back_key_function1 = make_combine_blocks_list_back_key_function(
         "a", numblocks=5, split_every=2
     )
     back_key_function2 = make_map_blocks_back_key_function("b")
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function2, [back_key_function1], [1]
+        back_key_function2, {"b": back_key_function1}
     )
 
-    check_back_key_function(fused_back_key_function, (0,), "([[('a', 0), ('a', 1)]],)")
-    check_back_key_function(fused_back_key_function, (1,), "([[('a', 2), ('a', 3)]],)")
-    check_back_key_function(fused_back_key_function, (2,), "([[('a', 4)]],)")
+    check_back_key_function(fused_back_key_function, (0,), "≪≪[('a', 0), ('a', 1)]≫≫")
+    check_back_key_function(fused_back_key_function, (1,), "≪≪[('a', 2), ('a', 3)]≫≫")
+    check_back_key_function(fused_back_key_function, (2,), "≪≪[('a', 4)]≫≫")
 
 
-def test_fuse_back_key_function_combine_blocks_iter_map_blocks():
+def test_fuse_back_key_function_combine_blocks_iter_map_blocks() -> None:
     back_key_function1 = make_combine_blocks_iter_back_key_function(
         "a", numblocks=5, split_every=2
     )
     back_key_function2 = make_map_blocks_back_key_function("b")
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function2, [back_key_function1], [1]
+        back_key_function2, {"b": back_key_function1}
     )
 
-    check_back_key_function(fused_back_key_function, (0,), "([<('a', 0), ('a', 1)>],)")
-    check_back_key_function(fused_back_key_function, (1,), "([<('a', 2), ('a', 3)>],)")
-    check_back_key_function(fused_back_key_function, (2,), "([<('a', 4)>],)")
+    check_back_key_function(fused_back_key_function, (0,), "≪≪<('a', 0), ('a', 1)>≫≫")
+    check_back_key_function(fused_back_key_function, (1,), "≪≪<('a', 2), ('a', 3)>≫≫")
+    check_back_key_function(fused_back_key_function, (2,), "≪≪<('a', 4)>≫≫")
 
 
-def test_fuse_back_key_function_combine_blocks_list_combine_blocks_list():
+def test_fuse_back_key_function_combine_blocks_list_combine_blocks_list() -> None:
     back_key_function1 = make_combine_blocks_list_back_key_function(
         "a", numblocks=5, split_every=2
     )
@@ -304,18 +393,18 @@ def test_fuse_back_key_function_combine_blocks_list_combine_blocks_list():
         "b", numblocks=3, split_every=2
     )
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function2, [back_key_function1], [1]
+        back_key_function2, {"b": back_key_function1}
     )
 
     check_back_key_function(
         fused_back_key_function,
         (0,),
-        "([[[('a', 0), ('a', 1)], [('a', 2), ('a', 3)]]],)",
+        "≪[≪[('a', 0), ('a', 1)]≫, ≪[('a', 2), ('a', 3)]≫]≫",
     )
-    check_back_key_function(fused_back_key_function, (1,), "([[[('a', 4)]]],)")
+    check_back_key_function(fused_back_key_function, (1,), "≪[≪[('a', 4)]≫]≫")
 
 
-def test_fuse_back_key_function_combine_blocks_iter_combine_blocks_iter():
+def test_fuse_back_key_function_combine_blocks_iter_combine_blocks_iter() -> None:
     back_key_function1 = make_combine_blocks_iter_back_key_function(
         "a", numblocks=5, split_every=2
     )
@@ -323,65 +412,81 @@ def test_fuse_back_key_function_combine_blocks_iter_combine_blocks_iter():
         "b", numblocks=3, split_every=2
     )
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function2, [back_key_function1], [1]
+        back_key_function2, {"b": back_key_function1}
     )
 
     check_back_key_function(
         fused_back_key_function,
         (0,),
-        "([<<('a', 0), ('a', 1)>, <('a', 2), ('a', 3)>>],)",
+        "≪<≪<('a', 0), ('a', 1)>≫, ≪<('a', 2), ('a', 3)>≫>≫",
     )
-    check_back_key_function(fused_back_key_function, (1,), "([<<('a', 4)>>],)")
+    check_back_key_function(fused_back_key_function, (1,), "≪<≪<('a', 4)>≫>≫")
 
 
-@pytest.mark.xfail(reason="https://github.com/cubed-dev/cubed/issues/414")
-def test_fuse_back_key_function_map_blocks_alternate_blocks_back_key_function():
+def test_fuse_back_key_function_map_blocks_alternate_blocks_back_key_function() -> None:
+    #
+    #  a   b
+    #  |   |
+    #  c   d
+    #   \ /
+    #   out
+    #
     back_key_function1 = make_map_blocks_back_key_function("a")
     back_key_function2 = make_map_blocks_back_key_function("b")
     back_key_function3 = make_alternate_blocks_back_key_function("c", "d")
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function3, [back_key_function1, back_key_function2], [1, 1]
+        back_key_function3, {"c": back_key_function1, "d": back_key_function2}
     )
 
-    check_back_key_function(fused_back_key_function, (0,), "(('a', 0),)")
-    check_back_key_function(fused_back_key_function, (1,), "(('b', 1),)")
-    check_back_key_function(fused_back_key_function, (2,), "(('a', 2),)")
-    check_back_key_function(fused_back_key_function, (3,), "(('b', 3),)")
+    check_back_key_function(fused_back_key_function, (0,), "≪≪('a', 0)≫≫")
+    check_back_key_function(fused_back_key_function, (1,), "≪≪('b', 1)≫≫")
+    check_back_key_function(fused_back_key_function, (2,), "≪≪('a', 2)≫≫")
+    check_back_key_function(fused_back_key_function, (3,), "≪≪('b', 3)≫≫")
 
 
-@pytest.mark.xfail(reason="https://github.com/cubed-dev/cubed/issues/414")
-def test_fuse_back_key_function_map_blocks_concat_blocks_back_key_function():
+def test_fuse_back_key_function_map_blocks_concat_blocks_back_key_function() -> None:
+    #
+    #  a   b
+    #  |   |
+    #  c   d
+    #   \ /
+    #   out
+    #
     back_key_function1 = make_map_blocks_back_key_function("a")
     back_key_function2 = make_map_blocks_back_key_function("b")
     back_key_function3 = make_concat_blocks_back_key_function("c", "d")
     fused_back_key_function = make_fused_back_key_function(
-        back_key_function3, [back_key_function1, back_key_function2], [1, 1]
+        back_key_function3, {"c": back_key_function1, "d": back_key_function2}
     )
 
-    check_back_key_function(fused_back_key_function, (0,), "(<('a', 0)>,)")
-    check_back_key_function(fused_back_key_function, (1,), "(<('a', 1), ('b', 0)>,)")
-    check_back_key_function(fused_back_key_function, (2,), "(<('b', 0), ('b', 1)>,)")
+    check_back_key_function(fused_back_key_function, (0,), "≪<≪('a', 0)≫>≫")
+    check_back_key_function(fused_back_key_function, (1,), "≪<≪('a', 1)≫, ≪('b', 0)≫>≫")
+    check_back_key_function(fused_back_key_function, (2,), "≪<≪('b', 0)≫, ≪('b', 1)≫>≫")
 
 
-def apply_blockwise(input_data, out_coords, bw_spec):
-    args = []
+def apply_blockwise(
+    input_data: dict[str, list[int]], out_coords: list[int], bw_spec: BlockwiseSpec
+) -> Any:
+    # just return the (1D) coord as a value
+    def get_data(key: ChunkKey) -> int:
+        logger.debug(f"get_data for f{key}")
+        name = key.name
+        index = key.coords[0]  # 1d index
+        return input_data[name][index]
+
+    logger.debug("Calling apply_blockwise...")
     out_key = ChunkKey(
         "out", tuple(out_coords)
     )  # array name is ignored by back_key_function
+    logger.debug("out_key: %s", out_key)
     in_keys = bw_spec.back_key_function(out_key)
-    for in_key in in_keys:
-        # just return the (1D) coord as a value
-        def get_data(key):
-            name = key.name
-            index = key.coords[0]  # 1d index
-            return input_data[name][index]
-
-        arg = map_nested(get_data, in_key)
-        args.append(arg)
-    return bw_spec.function(*args)
+    logger.debug("in_keys: %s", in_keys)
+    fargs = map_nested(get_data, in_keys)
+    logger.debug("fargs: %s", fargs)
+    return bw_spec.function(*fargs.args)
 
 
-def test_apply_blockwise():
+def test_apply_blockwise() -> None:
     bw_spec = make_blockwise_spec(
         back_key_function=make_map_blocks_back_key_function("a"),
         function=negative,
@@ -392,7 +497,7 @@ def test_apply_blockwise():
     assert out == [0, -1, -2, -3, -4]
 
 
-def test_apply_blockwise_multiple_inputs():
+def test_apply_blockwise_multiple_inputs() -> None:
     bw_spec = make_blockwise_spec(
         back_key_function=make_map_blocks_back_key_function("a", "b"), function=add
     )
@@ -402,7 +507,7 @@ def test_apply_blockwise_multiple_inputs():
     assert out == [5, 7, 9, 11, 13]
 
 
-def test_apply_blockwise_iterator():
+def test_apply_blockwise_iterator() -> None:
     bw_spec = make_blockwise_spec(
         back_key_function=make_combine_blocks_iter_back_key_function(
             "a", numblocks=5, split_every=2
@@ -415,9 +520,23 @@ def test_apply_blockwise_iterator():
     assert out == [1, 5, 4]
 
 
-def test_apply_blockwise_fused():
+def test_apply_blockwise_multiple_outputs() -> None:
+    bw_spec = make_blockwise_spec(
+        back_key_function=make_map_blocks_back_key_function("a"),
+        function=int_sqrts,
+    )
+
+    input_data = {"a": [0, 1, 4, 9, 16]}
+    out = [apply_blockwise(input_data, [i], bw_spec) for i in range(5)]
+    vals = [tuple(y for y in x) for x in out]
+    assert vals == [(0, 0), (1, -1), (2, -2), (3, -3), (4, -4)]
+
+
+def test_apply_blockwise_fused() -> None:
     bw_spec1 = make_blockwise_spec(
-        back_key_function=make_map_blocks_back_key_function("a"), function=negative
+        back_key_function=make_map_blocks_back_key_function("a"),
+        function=negative,
+        output_names={"b"},
     )
     bw_spec2 = make_blockwise_spec(
         back_key_function=make_map_blocks_back_key_function("b"), function=negative
@@ -430,17 +549,17 @@ def test_apply_blockwise_fused():
     assert out == [0, 1, 2, 3, 4]
 
 
-def test_apply_blockwise_fused_iterator():
+def test_apply_blockwise_fused_list() -> None:
     bw_spec1 = make_blockwise_spec(
-        back_key_function=make_map_blocks_back_key_function("a"), function=negative
+        back_key_function=make_map_blocks_back_key_function("a"),
+        function=negative,
+        output_names={"b"},
     )
     bw_spec2 = make_blockwise_spec(
-        back_key_function=make_combine_blocks_iter_back_key_function(
+        back_key_function=make_combine_blocks_list_back_key_function(
             "b", numblocks=5, split_every=2
         ),
-        function=sum_iter,
-        num_input_blocks=(2,),
-        iterable_input_blocks=(True,),
+        function=sum_list,
     )
 
     bw_spec = fuse_blockwise_specs(bw_spec2, bw_spec1)
@@ -450,9 +569,31 @@ def test_apply_blockwise_fused_iterator():
     assert out == [-1, -5, -4]
 
 
-def test_apply_blockwise_fused_iterator_with_single_input_block():
+def test_apply_blockwise_fused_iterator() -> None:
     bw_spec1 = make_blockwise_spec(
-        back_key_function=make_map_blocks_back_key_function("a"), function=negative
+        back_key_function=make_map_blocks_back_key_function("a"),
+        function=negative,
+        output_names={"b"},
+    )
+    bw_spec2 = make_blockwise_spec(
+        back_key_function=make_combine_blocks_iter_back_key_function(
+            "b", numblocks=5, split_every=2
+        ),
+        function=sum_iter,
+    )
+
+    bw_spec = fuse_blockwise_specs(bw_spec2, bw_spec1)
+
+    input_data = {"a": [0, 1, 2, 3, 4]}
+    out = [apply_blockwise(input_data, [i], bw_spec) for i in range(3)]
+    assert out == [-1, -5, -4]
+
+
+def test_apply_blockwise_fused_iterator_with_single_input_block() -> None:
+    bw_spec1 = make_blockwise_spec(
+        back_key_function=make_map_blocks_back_key_function("a"),
+        function=negative,
+        output_names={"b"},
     )
     # the iterator only reads from a single input block
     bw_spec2 = make_blockwise_spec(
@@ -460,8 +601,6 @@ def test_apply_blockwise_fused_iterator_with_single_input_block():
             "b", numblocks=5, split_every=1
         ),
         function=sum_iter,
-        num_input_blocks=(1,),
-        iterable_input_blocks=(True,),
     )
 
     bw_spec = fuse_blockwise_specs(bw_spec2, bw_spec1)
@@ -469,3 +608,90 @@ def test_apply_blockwise_fused_iterator_with_single_input_block():
     input_data = {"a": [0, 1, 2, 3, 4]}
     out = [apply_blockwise(input_data, [i], bw_spec) for i in range(5)]
     assert out == [0, -1, -2, -3, -4]
+
+
+def test_apply_blockwise_fused_iterators() -> None:
+    bw_spec1 = make_blockwise_spec(
+        back_key_function=make_combine_blocks_iter_back_key_function(
+            "a", numblocks=5, split_every=2
+        ),
+        function=sum_iter,
+        output_names={"b"},
+    )
+    bw_spec2 = make_blockwise_spec(
+        back_key_function=make_combine_blocks_iter_back_key_function(
+            "b", numblocks=3, split_every=2
+        ),
+        function=sum_iter,
+    )
+
+    bw_spec = fuse_blockwise_specs(bw_spec2, bw_spec1)
+
+    input_data = {"a": [0, 1, 2, 3, 4]}
+    out = [apply_blockwise(input_data, [i], bw_spec) for i in range(2)]
+    assert out == [6, 4]
+
+
+def test_apply_blockwise_alternate_blocks_fused() -> None:
+    bw_spec1 = make_blockwise_spec(
+        back_key_function=make_map_blocks_back_key_function("a"),
+        function=negative,
+        output_names={"c"},
+    )
+    bw_spec2 = make_blockwise_spec(
+        back_key_function=make_map_blocks_back_key_function("b"),
+        function=identity,
+        output_names={"d"},
+    )
+    bw_spec3 = make_blockwise_spec(
+        back_key_function=make_alternate_blocks_back_key_function("c", "d"),
+        function=identity,
+    )
+
+    bw_spec = fuse_blockwise_specs(bw_spec3, bw_spec1, bw_spec2)
+
+    input_data = {"a": [0, 2, 4, 6], "b": [1, 3, 5, 7]}
+    out = [apply_blockwise(input_data, [i], bw_spec) for i in range(4)]
+    assert out == [0, 3, -4, 7]
+
+
+def test_apply_blockwise_concat_blocks_fused() -> None:
+    bw_spec1 = make_blockwise_spec(
+        back_key_function=make_map_blocks_back_key_function("a"),
+        function=negative,
+        output_names={"c"},
+    )
+    bw_spec2 = make_blockwise_spec(
+        back_key_function=make_map_blocks_back_key_function("b"),
+        function=identity,
+        output_names={"d"},
+    )
+    bw_spec3 = make_blockwise_spec(
+        back_key_function=make_concat_blocks_back_key_function("c", "d"),
+        function=sum_iter,
+    )
+
+    bw_spec = fuse_blockwise_specs(bw_spec3, bw_spec1, bw_spec2)
+
+    input_data = {"a": [0, 1], "b": [2, 3]}
+    out = [apply_blockwise(input_data, [i], bw_spec) for i in range(3)]
+    assert out == [0, -1 + 2, 2 + 3]
+
+
+def test_apply_blockwise_multiple_outputs_fused() -> None:
+    bw_spec1 = make_blockwise_spec(
+        back_key_function=make_map_blocks_back_key_function("a"),
+        function=negative,
+        output_names={"b"},
+    )
+    bw_spec2 = make_blockwise_spec(
+        back_key_function=make_map_blocks_back_key_function("b"),
+        function=int_sqrts,
+    )
+
+    bw_spec = fuse_blockwise_specs(bw_spec2, bw_spec1)
+
+    input_data = {"a": [0, -1, -4, -9, -16]}
+    out = [apply_blockwise(input_data, [i], bw_spec) for i in range(5)]
+    vals = [tuple(y for y in x) for x in out]
+    assert vals == [(0, 0), (1, -1), (2, -2), (3, -3), (4, -4)]

--- a/cubed/tests/primitive/test_blockwise_fusion.py
+++ b/cubed/tests/primitive/test_blockwise_fusion.py
@@ -201,10 +201,14 @@ def make_blockwise_spec(
     function: Callable[..., Any],
     output_names: set[str] | None = None,
 ) -> BlockwiseSpec:
+    output_names = output_names or {"out"}
     return BlockwiseSpec(
         back_key_function=back_key_function,
         function=function,
-        output_names=output_names or {"out"},
+        num_input_blocks=(1,),  # not needed for this test
+        num_output_blocks=(1,),  # not needed for this test
+        reads_map={},  # not needed for this test
+        writes_map={name: None for name in output_names},  # only used for names
     )
 
 

--- a/cubed/tests/primitive/test_map_nested.py
+++ b/cubed/tests/primitive/test_map_nested.py
@@ -1,0 +1,68 @@
+from cubed.primitive.blockwise import map_nested
+
+
+def test_map_nested_lists():
+    inc = lambda x: x + 1
+
+    assert map_nested(inc, [1, 2]) == [2, 3]
+    assert map_nested(inc, [[1, 2]]) == [[2, 3]]
+    assert map_nested(inc, [[1, 2], [3, 4]]) == [[2, 3], [4, 5]]
+
+
+count = 0
+
+
+def inc(x):
+    global count
+    count = count + 1
+    return x + 1
+
+
+def test_map_nested_iterators():
+    # same tests as test_map_nested_lists, but use a counter to check that iterators are advanced at correct points
+    global count
+
+    out = map_nested(inc, iter([1, 2]))
+    assert isinstance(out, map)
+    assert count == 0
+    assert next(out) == 2
+    assert count == 1
+    assert next(out) == 3
+    assert count == 2
+
+    # reset count
+    count = 0
+
+    out = map_nested(inc, [iter([1, 2])])
+    assert isinstance(out, list)
+    assert count == 0
+    assert len(out) == 1
+    out = out[0]
+    assert isinstance(out, map)
+    assert count == 0
+    assert next(out) == 2
+    assert count == 1
+    assert next(out) == 3
+    assert count == 2
+
+    # reset count
+    count = 0
+
+    out = map_nested(inc, [iter([1, 2]), iter([3, 4])])
+    assert isinstance(out, list)
+    assert count == 0
+    assert len(out) == 2
+    out0 = out[0]
+    assert isinstance(out0, map)
+    assert count == 0
+    assert next(out0) == 2
+    assert count == 1
+    assert next(out0) == 3
+    assert count == 2
+    out1 = out[1]
+    assert isinstance(out1, map)
+    assert count == 2
+    assert next(out1) == 4
+    assert count == 3
+    assert next(out1) == 5
+    assert count == 4

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -22,7 +22,7 @@ from cubed.core.ops import (
 )
 from cubed.core.optimization import fuse_all_optimize_dag, multiple_inputs_optimize_dag
 from cubed.core.plan import ArrayRole
-from cubed.primitive.blockwise import ChunkKey
+from cubed.primitive.blockwise import ChunkKey, FunctionArgs
 from cubed.runtime.utils import raise_if_computes
 from cubed.storage.store import open_storage_array
 from cubed.tests.utils import ALL_EXECUTORS, MAIN_EXECUTORS, TaskCounter, create_zarr
@@ -1035,7 +1035,7 @@ def sqrts(x):
         yield -nxp.sqrt(x)
 
     def key_function(out_key):
-        return (ChunkKey(x.name, out_key.coords),)
+        return FunctionArgs(ChunkKey(x.name, out_key.coords), output_name=out_key.name)
 
     return general_blockwise(
         _sqrts,

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -22,6 +22,7 @@ from cubed.core.ops import (
 )
 from cubed.core.optimization import fuse_all_optimize_dag, multiple_inputs_optimize_dag
 from cubed.core.plan import ArrayRole
+from cubed.primitive.blockwise import ChunkKey
 from cubed.runtime.utils import raise_if_computes
 from cubed.storage.store import open_storage_array
 from cubed.tests.utils import ALL_EXECUTORS, MAIN_EXECUTORS, TaskCounter, create_zarr
@@ -1033,12 +1034,12 @@ def sqrts(x):
         yield nxp.sqrt(x)
         yield -nxp.sqrt(x)
 
-    def block_function(out_key):
-        return ((x.name,) + out_key[1:],)
+    def key_function(out_key):
+        return (ChunkKey(x.name, out_key.coords),)
 
     return general_blockwise(
         _sqrts,
-        block_function,
+        key_function,
         x,
         shapes=[x.shape, x.shape],
         dtypes=[x.dtype, x.dtype],

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -1034,12 +1034,12 @@ def sqrts(x):
         yield nxp.sqrt(x)
         yield -nxp.sqrt(x)
 
-    def key_function(out_key):
+    def back_key_function(out_key):
         return FunctionArgs(ChunkKey(x.name, out_key.coords), output_name=out_key.name)
 
     return general_blockwise(
         _sqrts,
-        key_function,
+        back_key_function,
         x,
         shapes=[x.shape, x.shape],
         dtypes=[x.dtype, x.dtype],

--- a/cubed/tests/test_optimization.py
+++ b/cubed/tests/test_optimization.py
@@ -1188,21 +1188,55 @@ def test_fuse_only_optimize_dag(spec):
     assert_array_equal(result, -np.ones((2, 2)))
 
 
+# stack
+#
+#  a   b    ->   c
+#   \ /
+#    c
+#
 def test_optimize_stack(spec):
-    # This test fails if stack's general_blockwise call doesn't have fusable_with_predecessors=False
     a = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
     b = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
     c = xp.stack((a, b), axis=0)
-    d = c + 1
-    # try to fuse all ops into one (d will fuse with c, but c won't fuse with a and b)
-    d.compute(optimize_function=fuse_multiple_levels())
+
+    opt_fn = fuse_multiple_levels()
+
+    c.visualize(optimize_function=opt_fn, show_hidden=True)
+
+    # check structure of optimized dag
+    expected_fused_dag = create_dag()
+    add_placeholder_op(expected_fused_dag, (), (c,))
+    optimized_dag = c._plan.optimize(optimize_function=opt_fn).dag
+    assert structurally_equivalent(
+        optimized_dag, expected_fused_dag, remove_hidden=True
+    )
+
+    # fuse all ops into one
+    c.compute(optimize_function=opt_fn)
 
 
+# concat
+#
+#  a   b    ->   c
+#   \ /
+#    c
+#
 def test_optimize_concat(spec):
-    # This test fails if concat's general_blockwise call doesn't have fusable_with_predecessors=False
     a = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
     b = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
     c = xp.concat((a, b), axis=0)
-    d = c + 1
-    # try to fuse all ops into one (d will fuse with c, but c won't fuse with a and b)
-    d.compute(optimize_function=fuse_multiple_levels())
+
+    opt_fn = fuse_multiple_levels()
+
+    c.visualize(optimize_function=opt_fn, show_hidden=True)
+
+    # check structure of optimized dag
+    expected_fused_dag = create_dag()
+    add_placeholder_op(expected_fused_dag, (), (c,))
+    optimized_dag = c._plan.optimize(optimize_function=opt_fn).dag
+    assert structurally_equivalent(
+        optimized_dag, expected_fused_dag, remove_hidden=True
+    )
+
+    # fuse all ops into one
+    c.compute(optimize_function=opt_fn)

--- a/cubed/tests/test_utils.py
+++ b/cubed/tests/test_utils.py
@@ -20,7 +20,6 @@ from cubed.utils import (
     normalize_shape,
     offset_to_block_id,
     peak_measured_mem,
-    split_into,
     to_chunksize,
 )
 
@@ -126,12 +125,6 @@ def test_extract_stack_summaries():
     assert stack_summaries[-1].name == "test_extract_stack_summaries"
     assert stack_summaries[-1].module == "cubed.tests.test_utils"
     assert not stack_summaries[-1].is_cubed()
-
-
-def test_split_into():
-    assert list(split_into([1, 2, 3, 4, 5, 6], [1, 2, 3])) == [[1], [2, 3], [4, 5, 6]]
-    assert list(split_into([1, 2, 3, 4, 5, 6], [2, 3])) == [[1, 2], [3, 4, 5]]
-    assert list(split_into([1, 2, 3, 4], [1, 2, 3, 4])) == [[1], [2, 3], [4], []]
 
 
 def test_broadcast_trick():

--- a/cubed/tests/test_utils.py
+++ b/cubed/tests/test_utils.py
@@ -16,7 +16,6 @@ from cubed.utils import (
     is_local_path,
     itemsize,
     join_path,
-    map_nested,
     memory_repr,
     normalize_shape,
     offset_to_block_id,
@@ -133,73 +132,6 @@ def test_split_into():
     assert list(split_into([1, 2, 3, 4, 5, 6], [1, 2, 3])) == [[1], [2, 3], [4, 5, 6]]
     assert list(split_into([1, 2, 3, 4, 5, 6], [2, 3])) == [[1, 2], [3, 4, 5]]
     assert list(split_into([1, 2, 3, 4], [1, 2, 3, 4])) == [[1], [2, 3], [4], []]
-
-
-def test_map_nested_lists():
-    inc = lambda x: x + 1
-
-    assert map_nested(inc, [1, 2]) == [2, 3]
-    assert map_nested(inc, [[1, 2]]) == [[2, 3]]
-    assert map_nested(inc, [[1, 2], [3, 4]]) == [[2, 3], [4, 5]]
-
-
-count = 0
-
-
-def inc(x):
-    global count
-    count = count + 1
-    return x + 1
-
-
-def test_map_nested_iterators():
-    # same tests as test_map_nested_lists, but use a counter to check that iterators are advanced at correct points
-    global count
-
-    out = map_nested(inc, iter([1, 2]))
-    assert isinstance(out, map)
-    assert count == 0
-    assert next(out) == 2
-    assert count == 1
-    assert next(out) == 3
-    assert count == 2
-
-    # reset count
-    count = 0
-
-    out = map_nested(inc, [iter([1, 2])])
-    assert isinstance(out, list)
-    assert count == 0
-    assert len(out) == 1
-    out = out[0]
-    assert isinstance(out, map)
-    assert count == 0
-    assert next(out) == 2
-    assert count == 1
-    assert next(out) == 3
-    assert count == 2
-
-    # reset count
-    count = 0
-
-    out = map_nested(inc, [iter([1, 2]), iter([3, 4])])
-    assert isinstance(out, list)
-    assert count == 0
-    assert len(out) == 2
-    out0 = out[0]
-    assert isinstance(out0, map)
-    assert count == 0
-    assert next(out0) == 2
-    assert count == 1
-    assert next(out0) == 3
-    assert count == 2
-    out1 = out[1]
-    assert isinstance(out1, map)
-    assert count == 2
-    assert next(out1) == 4
-    assert count == 3
-    assert next(out1) == 5
-    assert count == 4
 
 
 def test_broadcast_trick():

--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -5,7 +5,7 @@ import platform
 import sys
 import sysconfig
 import traceback
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import partial
 from itertools import islice
@@ -339,32 +339,6 @@ def split_into(iterable, sizes):
     it = iter(iterable)
     for size in sizes:
         yield list(islice(it, size))
-
-
-def map_nested(func, seq):
-    """Apply a function inside nested lists or iterators, while preserving
-    the nesting, and the collection or iterator type.
-
-    Examples
-    --------
-
-    >>> from cubed.utils import map_nested
-    >>> inc = lambda x: x + 1
-    >>> map_nested(inc, [[1, 2], [3, 4]])
-    [[2, 3], [4, 5]]
-
-    >>> it = map_nested(inc, iter([1, 2]))
-    >>> next(it)
-    2
-    >>> next(it)
-    3
-    """
-    if isinstance(seq, list):
-        return [map_nested(func, item) for item in seq]
-    elif isinstance(seq, Iterator):
-        return map(lambda item: map_nested(func, item), seq)
-    else:
-        return func(seq)
 
 
 def _broadcast_trick_inner(

--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -8,7 +8,6 @@ import traceback
 from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import partial
-from itertools import islice
 from math import prod
 from operator import add, mul
 from pathlib import Path
@@ -330,15 +329,6 @@ def convert_to_bytes(size: Union[int, float, str]) -> int:
         return size
     else:
         raise ValueError(f"Invalid value: {size}. Must be a positive value")
-
-
-# Based on more_itertools
-def split_into(iterable, sizes):
-    """Yield a list of sequential items from *iterable* of length 'n' for each
-    integer 'n' in *sizes*."""
-    it = iter(iterable)
-    for size in sizes:
-        yield list(islice(it, size))
 
 
 def _broadcast_trick_inner(


### PR DESCRIPTION
The motivation behind this PR was to fix #414, and also as a spin-off goal, toallow the blockwise key function to be property type checked.

Achieving #414 required a substantial change to the way that the (back) key functions work, and moving away from the assumption that the function to compute an array has the same set of inputs as the predecessor arrays in the DAG. To fix this, arrays are tracked by name (each array is already given a name in the DAG), rather than relying on positional order.

By re-writing in this way, it became possible to type check the key function code, including the code for fusing key functions, which is particularly delicate. (I used Claude Code to help with getting the type signatures working.)

Summary of changes
- Introduce a `ChunkKey` class, to allow type checking. It's not possible to type check the current representation of a tuple where the first element is a string (array name) and the second is a int tuple (the chunk coords).
- Rename `key_function` to `back_key_function` to emphasise that it maps output keys to input keys. (We may introduce a forward key function in the future to implement incremental updates.)
- Introduce `FunctionArgs` to model nested function calls. This makes implementing blockwise fusion possible.
- Remove `function_nargs` and `iterable_input_blocks` which were an imperfect attempt to provide information about the blockwise function arguments - imperfect because they couldn't handle the stack and concat implementation, hence #414. They are no longer needed with the above changes.
- Remove the limitation of stack and concat operations not being fusable with predecessor operations. This is tested in `test_optimize_stack` and `test_optimize_concat`
- Add many more test cases to test_blockwise_[fusion.py](https://fusion.py/).
- Add a short design document, DESIGN.md.