### PR TITLE
Add uv support and update contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,16 +1,45 @@
 # Contributing
 
-Contributions to Cubed are very welcome. Please head over to [GitHub](https://github.com/tomwhite/cubed) to get involved.
+Contributions to Cubed are very welcome. Please head over to [GitHub](https://github.com/cubed-dev/cubed) to get involved.
 
 ## Development
 
-Create an environment with
+
+
+### Using conda/pip
+
+Create an environment with:
 
 ```shell
 conda create --name cubed python=3.11
 conda activate cubed
-pip install -r requirements.txt
-pip install -e .
+pip install -e ".[test]"
 ```
+
+### Using uv
+
+Install the project with test dependencies:
+
+```shell
+uv sync --extra test
+```
+
+Run the tests:
+
+```shell
+uv run pytest
+```
+
+To include additional extras (e.g. Dask support), add more `--extra` flags:
+
+```shell
+uv sync --extra test --extra dask
+```
+
+> **Note:** Do not use `--all-extras`, as it includes backend-specific extras
+> (Beam, Lithops, Modal, Coiled) that have conflicting or platform-specific
+> dependencies and are not needed for local development.
+
+### Additional dependencies
 
 Make sure `graphviz` is installed on your machine (see [these instructions](https://graphviz.org/download/)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,28 @@ homepage = "https://github.com/cubed-dev/cubed"
 documentation = "https://tomwhite.github.io/cubed"
 repository = "https://github.com/cubed-dev/cubed"
 
+[tool.uv]
+# Backend extras are mutually exclusive and should not be resolved together.
+# Without this, uv's universal resolver can't satisfy all extras across
+# Python 3.11-3.14 (e.g. pandas 3.x on Python 3.14 needs numpy >= 2.3.3,
+# but apache-beam < 2.71 needs numpy < 2.3.0).
+conflicts = [
+    [
+        { extra = "beam" },
+        { extra = "lithops" },
+        { extra = "lithops-aws" },
+        { extra = "lithops-gcp" },
+        { extra = "modal" },
+        { extra = "modal-gcp" },
+        { extra = "coiled" },
+    ],
+]
+
+# apache-beam doesn't declare setuptools as a build dependency but needs it
+# (pkg_resources was removed from the stdlib in Python 3.12)
+[tool.uv.extra-build-dependencies]
+apache-beam = ["setuptools"]
+
 [tool.pytest.ini_options]
 filterwarnings = [
     "error::UserWarning",


### PR DESCRIPTION
### What changes

- Add [tool.uv] config to pyproject.toml with conflicts for mutually exclusive backend extras (beam, lithops, modal, coiled) and extra-build-dependencies for apache-beam's missing setuptools dep
- Rewrite docs/contributing.md with uv instructions, updated conda/pip instructions, and fix GitHub URL

For context, these changes were helpful when looking at  https://github.com/cubed-dev/cubed/issues/876