### PR TITLE
Add compatibility with Zarr 3.2.0

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -625,10 +625,20 @@ def elemwise(func, *args: "Array", dtype=None) -> "Array":
 
 def _create_zarr_indexer(selection, shape, chunks):
     if zarr.__version__[0] == "3":
-        from zarr.core.chunk_grids import RegularChunkGrid
         from zarr.core.indexing import OrthogonalIndexer
 
-        return OrthogonalIndexer(selection, shape, RegularChunkGrid(chunk_shape=chunks))
+        try:
+            from zarr.core.chunk_grids import ChunkGrid
+
+            return OrthogonalIndexer(
+                selection, shape, ChunkGrid.from_sizes(shape, chunks)
+            )
+        except ImportError:
+            from zarr.core.chunk_grids import RegularChunkGrid
+
+            return OrthogonalIndexer(
+                selection, shape, RegularChunkGrid(chunk_shape=chunks)
+            )
     else:
         from zarr.indexing import OrthogonalIndexer
 

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -633,7 +633,7 @@ def _create_zarr_indexer(selection, shape, chunks):
             return OrthogonalIndexer(
                 selection, shape, ChunkGrid.from_sizes(shape, chunks)
             )
-        except ImportError:
+        except (ImportError, AttributeError):
             from zarr.core.chunk_grids import RegularChunkGrid
 
             return OrthogonalIndexer(

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -581,8 +581,8 @@ def test_default_spec_allowed_mem_exceeded_visualize(tmp_path):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         b.visualize(filename=str(tmp_path / "cubed"))
-        assert len(w) == 1
-        assert "exceed allowed memory" in str(w[0].message)
+        mem_warnings = [x for x in w if "exceed allowed memory" in str(x.message)]
+        assert len(mem_warnings) == 1
 
 
 def test_default_spec_config_override():


### PR DESCRIPTION
We changed some internals when adding variable chunks support in zarr-python. This PR makes cubed compatible with the future zarr-python 3.2.0 release.