### PR TITLE
Enforce rechunking for sharded Icechunk store

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -209,8 +209,10 @@ def _store_array(
             sharding_enabled = target.shards is not None
             sharding_misaligned = target.shards != source.chunks
             if sharding_enabled and sharding_misaligned:
-                warn_msg = "There is a mismatch between the shard and chunk size. " \
-                "Rechunking will be applied to match the shard size and prevent data corruption."
+                warn_msg = (
+                    "There is a mismatch between the shard and chunk size. "
+                    "Rechunking will be applied to match the shard size and prevent data corruption."
+                )
                 warn(warn_msg, stacklevel=2)
                 source = source.rechunk(target.shards)
     if not is_storage_array(target):

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -204,6 +204,15 @@ def _store_array(
             raise ValueError("Target store must be specified when setting a region")
         else:
             return source
+    else:
+        if hasattr(target, "shards"):
+            sharding_enabled = target.shards is not None
+            sharding_misaligned = target.shards != source.chunks
+            if sharding_enabled and sharding_misaligned:
+                warn_msg = "There is a mismatch between the shard and chunk size. " \
+                "Rechunking will be applied to match the shard size and prevent data corruption."
+                warn(warn_msg, stacklevel=2)
+                source = source.rechunk(target.shards)
     if not is_storage_array(target):
         target = lazy_zarr_array(
             target,

--- a/cubed/icechunk.py
+++ b/cubed/icechunk.py
@@ -45,10 +45,6 @@ def store_icechunk(
 
     arrays = []
     for source, target, region in zip(sources, targets, regions_list):
-        sharding_enabled = target.shards is not None
-        sharding_misaligned = target.shards != source.chunks
-        if sharding_enabled and sharding_misaligned:
-            source = source.rechunk(target.shards)
         array = _store_array(
             source,
             target,

--- a/cubed/icechunk.py
+++ b/cubed/icechunk.py
@@ -45,6 +45,10 @@ def store_icechunk(
 
     arrays = []
     for source, target, region in zip(sources, targets, regions_list):
+        sharding_enabled = target.shards is not None
+        sharding_misaligned = target.shards != source.chunks
+        if sharding_enabled and sharding_misaligned:
+            source = source.rechunk(target.shards)
         array = _store_array(
             source,
             target,

--- a/cubed/tests/test_icechunk.py
+++ b/cubed/tests/test_icechunk.py
@@ -157,7 +157,8 @@ def test_store_icechunk_sharded(icechunk_storage, executor):
     store = fork.store
     group = zarr.open_group(store=store)
     target = group.get("a")
-    merged_session = store_icechunk(sources=a, targets=target, executor=executor)
+    with pytest.warns(UserWarning, match="mismatch between the shard and chunk size"):
+        merged_session = store_icechunk(sources=a, targets=target, executor=executor)
     session.merge(merged_session)
     session.commit("commit 1")
 

--- a/cubed/tests/test_icechunk.py
+++ b/cubed/tests/test_icechunk.py
@@ -31,7 +31,7 @@ def icechunk_storage(tmpdir) -> "Storage":
     return Storage.new_local_filesystem(str(tmpdir))
 
 
-def create_icechunk(a, icechunk_storage, /, *, dtype=None, chunks=None):
+def create_icechunk(a, icechunk_storage, /, *, dtype=None, chunks=None, shards=None):
     # from dask.asarray
     if not isinstance(getattr(a, "shape", None), Iterable):
         # ensure blocks are arrays
@@ -44,7 +44,9 @@ def create_icechunk(a, icechunk_storage, /, *, dtype=None, chunks=None):
     store = session.store
 
     group = zarr.group(store=store, overwrite=True)
-    arr = group.create_array("a", shape=a.shape, dtype=dtype, chunks=chunks)
+    arr = group.create_array(
+        "a", shape=a.shape, dtype=dtype, chunks=chunks, shards=shards
+    )
 
     arr[...] = a
 
@@ -135,4 +137,37 @@ def test_store_icechunk_region(icechunk_storage, executor):
                 [0, 0, 0, 0, 0],
             ]
         ),
+    )
+
+
+def test_store_icechunk_sharded(icechunk_storage, executor):
+    a = xp.asarray(
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]],
+        chunks=(2, 2),
+    )
+    create_icechunk(
+        np.zeros((4, 4), dtype=int), icechunk_storage, chunks=(2, 2), shards=(4, 4)
+    )
+
+    # note that the same zarr store is overwritten in the following tests
+
+    repo = Repository.open(storage=icechunk_storage)
+    session = repo.writable_session("main")
+    fork = session.fork()
+    store = fork.store
+    group = zarr.open_group(store=store)
+    target = group.get("a")
+    merged_session = store_icechunk(sources=a, targets=target, executor=executor)
+    session.merge(merged_session)
+    session.commit("commit 1")
+
+    # reopen store and check contents of array
+    repo = Repository.open(icechunk_storage)
+    session = repo.readonly_session(branch="main")
+    store = session.store
+
+    group = zarr.open_group(store=store, mode="r")
+    assert_array_equal(
+        cubed.from_array(group["a"])[:],
+        a,
     )


### PR DESCRIPTION
This PR solves issue #896 by enforcing a rechunking of the input array, if the output store is sharded and the input chunks do not match the shards. 

Should we add a warning to notify the users that there is a mismatch of `cubed` chunks and Zarr `shards`? 