### PR TITLE
Add `chunks` parameter to `from_zarr`

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -105,7 +105,7 @@ def _from_array(block, input_array, outchunks=None, asarray=None, block_id=None)
     return out
 
 
-def from_zarr(store, path=None, spec=None) -> "Array":
+def from_zarr(store, path=None, chunks=None, spec=None) -> "Array":
     """Load an array from Zarr storage.
 
     Parameters
@@ -114,6 +114,11 @@ def from_zarr(store, path=None, spec=None) -> "Array":
         Input Zarr store
     path : string, optional
         Group path
+    chunks : tuple of ints, optional
+         If set, merge zarr chunks up to this size before downstream ops.
+        Each downstream task reads a ``chunks``-sized region (spanning
+        multiple zarr chunks). ``chunks`` must be an exact multiple of
+        the zarr chunk size in every dimension.
     spec : cubed.Spec, optional
         The spec to use for the computation.
 
@@ -134,7 +139,10 @@ def from_zarr(store, path=None, spec=None) -> "Array":
     from cubed.array_api import Array
 
     plan = Plan._new(name, "from_zarr", target)
-    return Array(name, target, spec, plan)
+    arr = Array(name, target, spec, plan)
+    if chunks is not None:
+        arr = merge_chunks(arr, chunks)
+    return arr
 
 
 def store(

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -124,6 +124,19 @@ def test_from_zarr(tmp_path, spec, executor, path, zarr_format):
     )
 
 
+@pytest.mark.parametrize("chunks", [None, (2, 2), (6, 6)])
+def test_from_zarr_chunks(tmp_path, chunks):
+    store = store = tmp_path / "source.zarr"
+    create_zarr(
+        np.ones((10, 10)),
+        chunks=(2, 2),
+        store=store,
+    )
+    a = cubed.from_zarr(store, chunks=chunks)
+    assert a.chunks == chunks or (2, 2)
+    assert_array_equal(a.compute(), np.ones((10, 10)))
+
+
 def test_store(tmp_path, spec, executor):
     a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
 


### PR DESCRIPTION
...to allow Zarr stores to be opened with a coarser chunking than stored on disk.