### PR TITLE
Add cubed.random.integers(): deterministic int array via Wang hash

### DIFF
--- a/cubed/random.py
+++ b/cubed/random.py
@@ -1,9 +1,17 @@
+import math
 import random as pyrandom
+
+import numpy as np
 
 from cubed.backend_array_api import namespace as nxp
 from cubed.backend_array_api import numpy_array_to_backend_array
 from cubed.core.ops import map_blocks
-from cubed.utils import block_id_to_offset, normalize_chunks, normalize_shape
+from cubed.utils import (
+    block_id_to_offset,
+    normalize_chunks,
+    normalize_shape,
+    to_chunksize,
+)
 
 
 def random(size, *, dtype=nxp.float64, chunks=None, spec=None):
@@ -33,3 +41,69 @@ def _random(x, numblocks=None, root_seed=None, dtype=nxp.float64, block_id=None)
     out = rg.random(x.shape, dtype=dtype)
     out = numpy_array_to_backend_array(out)
     return out
+
+
+def integers(shape, *, dtype=nxp.int32, chunks=None, spec=None):
+    """Return a deterministic integer array where element[i] = wang_hash(flat_index(i)).
+
+    Each element's value depends only on its position in the array, not on chunking.
+    This means the same logical array can be regenerated at any chunk layout and
+    compared element-wise — making it suitable for rechunk validation and I/O benchmarks.
+
+    The Wang hash produces output with no constant-delta pattern between adjacent
+    elements, so the array is effectively incompressible under shuffle-based codecs
+    (comparable to float32 random data).
+
+    Parameters
+    ----------
+    shape : int or tuple of ints
+        Shape of the array.
+    dtype : dtype, optional
+        Integer dtype for the output. Default is int32.
+    chunks : tuple of ints, optional
+        Chunk shape. Defaults to the array shape (single chunk).
+    spec : cubed.Spec, optional
+        The spec to use for the computation.
+
+    Returns
+    -------
+    cubed.Array
+        A lazy integer array backed by wang_hash(flat_index).
+    """
+    shape = normalize_shape(shape)
+    chunks = normalize_chunks(chunks, shape=shape, dtype=dtype)
+    chunksize = to_chunksize(chunks)
+    return map_blocks(
+        _integers,
+        dtype=dtype,
+        chunks=chunks,
+        spec=spec,
+        _shape=shape,
+        _chunksize=chunksize,
+    )
+
+
+def _integers(x, _shape, _chunksize, block_id=None):
+    strides = [math.prod(_shape[i + 1 :]) for i in range(len(_shape))]
+    flat = nxp.zeros(x.shape, dtype=nxp.int64)
+    for ax, (stride, cs) in enumerate(zip(strides, _chunksize)):
+        origin = block_id[ax] * cs
+        idx = nxp.arange(origin, origin + x.shape[ax], dtype=nxp.int64)
+        flat = (
+            flat
+            + nxp.reshape(idx, tuple(-1 if j == ax else 1 for j in range(len(_shape))))
+            * stride
+        )
+    # _wang_hash uses numpy-specific .view(); convert and convert back
+    hashed = _wang_hash(np.asarray(flat, dtype=np.uint32))
+    return numpy_array_to_backend_array(hashed).astype(x.dtype)
+
+
+def _wang_hash(n):
+    """Bijective 32-bit Wang hash applied elementwise to a uint32 numpy array."""
+    n = (n ^ np.uint32(61)) ^ (n >> np.uint32(16))
+    n = n + (n << np.uint32(3))
+    n = n ^ (n >> np.uint32(4))
+    n = n * np.uint32(0x27D4EB2D)
+    n = n ^ (n >> np.uint32(15))
+    return n.view(np.int32)

--- a/cubed/tests/test_random.py
+++ b/cubed/tests/test_random.py
@@ -1,5 +1,7 @@
+import math
 import random
 
+import numpy as np
 import pytest
 
 import cubed
@@ -7,6 +9,7 @@ import cubed.array_api as xp
 import cubed.random
 from cubed._testing import assert_array_equal
 from cubed.backend_array_api import namespace as nxp
+from cubed.random import _wang_hash
 from cubed.tests.utils import MAIN_EXECUTORS
 
 
@@ -68,3 +71,41 @@ def test_random_seed(spec, executor):
     b_result = b.compute(executor=executor)
 
     assert_array_equal(a_result, b_result)
+
+
+def test_integers():
+    a = cubed.random.integers((10, 10), chunks=(4, 5))
+
+    assert a.shape == (10, 10)
+    assert a.chunks == ((4, 4, 2), (5, 5))
+    assert a.dtype == nxp.int32
+
+    result = a.compute()
+
+    # values match wang_hash(flat_index)
+    shape = (10, 10)
+    strides = [math.prod(shape[i + 1 :]) for i in range(len(shape))]
+    for idx in [(0, 0), (0, 1), (3, 4), (9, 9)]:
+        flat = sum(i * s for i, s in zip(idx, strides))
+        assert result[idx] == _wang_hash(np.array([flat], dtype=np.uint32))[0]
+
+    # no constant-delta pattern (output is incompressible)
+    deltas = nxp.diff(nxp.astype(nxp.reshape(result, (-1,)), nxp.int64))
+    assert not nxp.all(deltas == deltas[0])
+
+
+def test_integers_dtype():
+    a = cubed.random.integers((10, 10), dtype=nxp.int64, chunks=(4, 5))
+
+    assert a.dtype == nxp.int64
+    result = a.compute()
+    assert result.dtype == nxp.int64
+
+
+def test_integers_chunking_independent():
+    # same logical array, different chunking — values must be identical
+    shape = (10, 8)
+    a = cubed.random.integers(shape, chunks=(5, 4))
+    b = cubed.random.integers(shape, chunks=(2, 8))
+
+    assert_array_equal(a.compute(), b.compute())

--- a/cubed/tests/test_rechunk_hypothesis.py
+++ b/cubed/tests/test_rechunk_hypothesis.py
@@ -42,11 +42,11 @@ def test_rechunk(rechunk_shapes):
 
     print(rechunk_shapes)
 
-    itemsize = 8
+    itemsize = 4
     allowed_mem = int(max(source_chunks_size, target_chunks_size) * itemsize * 1.1) * 5
 
     spec = cubed.Spec(allowed_mem=allowed_mem)
-    a = xp.ones(shape, chunks=source_chunks, spec=spec)
+    a = cubed.random.integers(shape, chunks=source_chunks, spec=spec)
     b = a.rechunk(target_chunks)
     plan = b.plan()
     assume(plan.num_tasks < 500)  # don't want to run too many tasks locally
@@ -54,7 +54,8 @@ def test_rechunk(rechunk_shapes):
         f"plan: num_stages: {plan.num_stages}, num_tasks: {plan.num_tasks}, max_projected_mem: {plan.max_projected_mem}"
     )
 
-    assert_array_equal(b.compute(), nxp.ones(shape))
+    expected = cubed.random.integers(shape, chunks=target_chunks, spec=spec)
+    assert bool(xp.all(xp.equal(b, expected)).compute())
 
 
 def test_rechunk_example():


### PR DESCRIPTION
The idea behind this is to produce incompressible data that can be easily validated after a rechunk operation.

This PR was authored with assistance from Claude Code.