### PR TITLE
Fix negative slice indexing when combined with int indexing

### DIFF
--- a/cubed/core/indexing.py
+++ b/cubed/core/indexing.py
@@ -47,9 +47,13 @@ def index(x, key):
 
     # Use trick from xarray for negative step values
     where_negative_step = []
+    num_integer_dims = 0
     for i, ia in enumerate(idx.args):
-        if isinstance(ia, ndindex.Slice) and ia.step < 0:
-            where_negative_step.append(i)
+        if isinstance(ia, ndindex.Integer):
+            num_integer_dims += 1
+        elif isinstance(ia, ndindex.Slice) and ia.step < 0:
+            # Axis in the output drops integer-indexed dimensions, so adjust
+            where_negative_step.append(i - num_integer_dims)
             pos_slice = _convert_slice_with_negative_step(selection[i], x.shape[i])
             selection[i] = pos_slice
     where_negative_step = tuple(where_negative_step)

--- a/cubed/tests/test_array_api.py
+++ b/cubed/tests/test_array_api.py
@@ -299,6 +299,7 @@ def test_index_1d(spec, ind):
         (slice(None), slice(2, 4), xp.newaxis),
         (slice(None), 1),
         (1, slice(2, 4)),
+        (0, slice(1, None, -1)),
     ],
 )
 def test_index_2d(spec, ind):
@@ -374,6 +375,14 @@ def test_index_1d_step(spec, shape, chunks, ind, new_chunks_expected):
             (4, 4),
             (slice(14, 3, -2), slice(14, 3, -3)),
             ((4, 2), (4,),),
+        ),
+        # integer index on axis 0 drops a dimension; negative step on axis 1
+        # must flip on axis 0 of the output, not axis 1 of the input
+        (
+            (1, 2),
+            (1, 2),
+            (0, slice(1, None, -1)),
+            ((2,),),
         ),
     ],
 )


### PR DESCRIPTION
The bug was found by Hypothesis (https://github.com/cubed-dev/cubed/actions/runs/27402916092/job/80984954012):

```
FAILED array_api_tests/test_array_object.py::test_getitem - numpy.exceptions.AxisError: Axis 1 is out of bounds for array of dimension 1

========== FAILING CODE SNIPPET:
cubed.Array<array-4253, shape=(1, 2), dtype=bool, chunks=((1,), (2,))>[(0, slice(1, None, -1))]
====================

Falsifying example: test_getitem(
    shape=(1, 2),
    dtype=numpy.bool,  # or any other generated value
    data=data(...),
)
Draw 1 (obj): [[False, False]]
x=cubed.Array<array-4253, shape=(1, 2), dtype=bool, chunks=((1,), (2,))>
Draw 2 (key): (0, slice(1, None, -1))
Explanation:
    These lines were always and only run by failing examples:
        /home/runner/work/cubed/cubed/cubed/cubed/core/indexing.py:52
        /home/runner/work/cubed/cubed/cubed/cubed/core/indexing.py:81
        /home/runner/work/cubed/cubed/cubed/cubed/core/indexing.py:149
        /home/runner/work/cubed/cubed/cubed/cubed/core/indexing.py:152
        /home/runner/work/cubed/cubed/cubed/cubed/core/indexing.py:169
        (and 9 more with settings.verbosity >= verbose)

You can reproduce this example by temporarily adding @reproduce_failure('6.155.2', b'AXicY3RkZHRkYnBkYABiIGQEYyBkAAMALkgClA==') as a decorator on your test case
```

And fixed with the help of Claude Code.